### PR TITLE
Syntax Error: missing comma between function parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords='causality causal-inference statistics graphical-model',
 
     packages=find_packages(exclude=['docs', 'tests']),
-    python_requires='>=3.0'
+    python_requires='>=3.0',
 
     install_requires=['numpy', 'scikit-learn', 'matplotlib', 'scipy', 
             'pandas', 'pygraphviz', 'networkx', 'sympy'],  


### PR DESCRIPTION
flake8 testing of https://github.com/Microsoft/dowhy on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./setup.py:47:20: E999 SyntaxError: invalid syntax
    install_requires=['numpy', 'scikit-learn', 'matplotlib', 'scipy', 
                   ^
1     E999 SyntaxError: invalid syntax
1
```