### PR TITLE
Fix flake8 warnings & errors

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -1,16 +1,16 @@
-import abc
-import numpy as np
-import sympy as sp
 import logging
 
-class CausalEstimator:
+import numpy as np
+import sympy as sp
 
+
+class CausalEstimator:
     """Base class for an estimator of causal effect.
 
     """
 
     def __init__(self, data, identified_estimand, treatment, outcome,
-            test_significance, params=None):
+                 test_significance, params=None):
         """Initializes an estimator with data and names of relevant variables.
 
         More description.
@@ -35,9 +35,7 @@ class CausalEstimator:
             for key, value in params.items():
                 setattr(self, key, value)
 
-
         self.logger = logging.getLogger(__name__)
-
 
     def estimate_effect(self):
         """TODO.
@@ -51,7 +49,7 @@ class CausalEstimator:
         self._treatment = self._data[self._treatment_name]
         self._outcome = self._data[self._outcome_name]
         est = self._estimate_effect()
-        #self._estimate = est
+        # self._estimate = est
 
         if self._significance_test is not None:
             signif_dict = self.test_significance(est)
@@ -77,26 +75,24 @@ class CausalEstimator:
 
         sorted_null_estimates = np.sort(null_estimates)
         self.logger.debug("Null estimates: {0}".format(sorted_null_estimates))
-        median_estimate = sorted_null_estimates[int(num_simulations/2)]
+        median_estimate = sorted_null_estimates[int(num_simulations / 2)]
         # Doing a two-sided test
         if estimate.value > median_estimate:
             # Being conservative with the p-value reported
             estimate_index = np.searchsorted(sorted_null_estimates, estimate.value, side="left")
-            p_value = 1 - (estimate_index/num_simulations)
-        if estimate_index < num_simulations/2:
+            p_value = 1 - (estimate_index / num_simulations)
+        if estimate_index < num_simulations / 2:
             # Being conservative with the p-value reported
             estimate_index = np.searchsorted(sorted_null_estimates, estimate.value, side="right")
-            p_value = (estimate_index/num_simulations)
+            p_value = (estimate_index / num_simulations)
         signif_dict = {
-                'p_value': p_value,
-                'sorted_null_estimates': sorted_null_estimates
-                }
+            'p_value': p_value,
+            'sorted_null_estimates': sorted_null_estimates
+        }
         return signif_dict
 
 
-
 class CausalEstimate:
-
     """TODO.
 
     """
@@ -125,10 +121,12 @@ class CausalEstimate:
             s += "p-value: {0}\n".format(self.significance_test["p_value"])
         return s
 
+
 class RealizedEstimand(object):
+
     def __init__(self, identified_estimand, estimator_name):
         self.treatment_variable = identified_estimand.treatment_variable
-        self.outcome_variable =  identified_estimand.outcome_variable
+        self.outcome_variable = identified_estimand.outcome_variable
         self.backdoor_variables = identified_estimand.backdoor_variables
         self.instrumental_variables = identified_estimand.instrumental_variables
         self.estimand_type = identified_estimand.estimand_type
@@ -143,12 +141,11 @@ class RealizedEstimand(object):
         self.estimand_expression = estimand_expression
 
     def __str__(self):
-        s =  "Realized estimand: {0}\n".format(self.estimator_name)
+        s = "Realized estimand: {0}\n".format(self.estimator_name)
         s += "Realized estimand type: {0}\n".format(self.estimand_type)
         s += "Estimand expression:\n{0}\n".format(sp.pretty(self.estimand_expression))
         j = 1
         for ass_name, ass_str in self.assumptions.items():
             s += "Estimand assumption {0}, {1}: {2}\n".format(j, ass_name, ass_str)
-            j +=1
+            j += 1
         return s
-

--- a/dowhy/causal_estimators/__init__.py
+++ b/dowhy/causal_estimators/__init__.py
@@ -3,15 +3,16 @@ from importlib import import_module
 
 from dowhy.causal_estimator import CausalEstimator
 
+
 def get_class_object(method_name, *args, **kwargs):
     # from https://www.bnmetrics.com/blog/factory-pattern-in-python3-simple-version
     try:
         module_name = method_name
-        class_name=string.capwords(method_name, "_").replace('_','')
+        class_name = string.capwords(method_name, "_").replace('_', '')
         print(class_name)
 
         estimator_module = import_module('.' + module_name,
-                package = "dowhy.causal_estimators")
+                                         package="dowhy.causal_estimators")
         estimator_class = getattr(estimator_module, class_name)
         assert issubclass(estimator_class, CausalEstimator)
 
@@ -19,7 +20,3 @@ def get_class_object(method_name, *args, **kwargs):
         print("No such estimator class exists!")
         raise ImportError('{} is not an existing causal estimator.'.format(method_name))
     return estimator_class
-
-
-
-

--- a/dowhy/causal_estimators/instrumental_variable_estimator.py
+++ b/dowhy/causal_estimators/instrumental_variable_estimator.py
@@ -1,12 +1,13 @@
 import numpy as np
-import pandas as pd
 import sympy as sp
 import sympy.stats as spstats
-import copy
-from dowhy.causal_estimator import CausalEstimator, CausalEstimate, RealizedEstimand
+
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
+from dowhy.causal_estimator import RealizedEstimand
+
 
 class InstrumentalVariableEstimator(CausalEstimator):
-
     """Compute effect of treatment using the instrumental variables method.
 
     This is a superclass that is inherited by other specific methods.
@@ -15,7 +16,7 @@ class InstrumentalVariableEstimator(CausalEstimator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.logger.debug("Instrumental Variables used:" +
-                ",".join(self._target_estimand.instrumental_variables))
+                          ",".join(self._target_estimand.instrumental_variables))
         self._instrument_names = self._target_estimand.instrumental_variables
 
         # choosing the instrumental variable to use
@@ -33,46 +34,55 @@ class InstrumentalVariableEstimator(CausalEstimator):
         instrument = self.estimating_instrument
         self.logger.debug("Instrument Variable values: {0}".format(instrument))
         num_unique_values = len(np.unique(instrument))
-        instrument_is_binary= (num_unique_values <=2)
+        instrument_is_binary = (num_unique_values <= 2)
         if instrument_is_binary:
             # Obtain estimate by Wald Estimator
-            y1_z =np.mean(self._outcome[instrument==1])
-            y0_z = np.mean(self._outcome[instrument==0])
-            x1_z = np.mean(self._treatment[instrument==1])
-            x0_z = np.mean(self._treatment[instrument==0])
+            y1_z = np.mean(self._outcome[instrument == 1])
+            y0_z = np.mean(self._outcome[instrument == 0])
+            x1_z = np.mean(self._treatment[instrument == 1])
+            x0_z = np.mean(self._treatment[instrument == 0])
             num = y1_z - y0_z
             deno = x1_z - x0_z
-            iv_est = num/deno
+            iv_est = num / deno
         else:
             # Obtain estimate by Pearl (1995) ratio estimator.
             # y = x+ u; multiply both sides by z and take expectation.
             num_yz = np.dot(self._outcome, instrument)
             deno_xz = np.dot(self._treatment, instrument)
-            iv_est = num_yz/deno_xz
+            iv_est = num_yz / deno_xz
 
-        estimate = CausalEstimate(estimate= iv_est,
-                target_estimand=self._target_estimand,
-                realized_estimand_expr = self.symbolic_estimator)
+        estimate = CausalEstimate(estimate=iv_est,
+                                  target_estimand=self._target_estimand,
+                                  realized_estimand_expr=self.symbolic_estimator)
         return estimate
 
     def construct_symbolic_estimator(self, estimand):
-        sym_outcome = (spstats.Normal(estimand.outcome_variable, 0,1))
-        sym_treatment = (spstats.Normal(estimand.treatment_variable,0,1))
-        sym_instrument = sp.Symbol(estimand.instrumental_variables[0])#",".join(estimand.instrumental_variables))
+        sym_outcome = (spstats.Normal(estimand.outcome_variable, 0, 1))
+        sym_treatment = (spstats.Normal(estimand.treatment_variable, 0, 1))
+        sym_instrument = sp.Symbol(estimand.instrumental_variables[0])
         sym_outcome_derivative = sp.Derivative(sym_outcome, sym_instrument)
-        sym_treatment_derivative =  sp.Derivative(sym_treatment, sym_instrument)
-        sym_effect = spstats.Expectation(sym_outcome_derivative) / sp.stats.Expectation(sym_treatment_derivative)
-        estimator_assumptions ={
-                "treatment_effect_homogeneity": "Each unit's treatment {0} is".format(self._treatment_name) +
-                "affected in the same way by common causes of {0} and {1}".format(self._treatment_name, self._outcome_name),
-                "outcome_effect_homogeneity": "Each unit's outcome {0} is".format(self._outcome_name) +
-                "affected in the same way by common causes of {0} and {1}".format(self._treatment_name, self._outcome_name),
-                }
+        sym_treatment_derivative = sp.Derivative(sym_treatment, sym_instrument)
+        sym_effect = (
+                spstats.Expectation(sym_outcome_derivative) /
+                sp.stats.Expectation(sym_treatment_derivative)
+        )
+        estimator_assumptions = {
+            "treatment_effect_homogeneity": (
+                "Each unit's treatment {0} is".format(self._treatment_name) +
+                "affected in the same way by common causes of "
+                "{0} and {1}".format(self._treatment_name, self._outcome_name)
+            ),
+            "outcome_effect_homogeneity": (
+                "Each unit's outcome {0} is".format(self._outcome_name) +
+                "affected in the same way by common causes of "
+                "{0} and {1}".format(self._treatment_name, self._outcome_name)
+            ),
+        }
         sym_assumptions = {**estimand.estimands["iv"]["assumptions"],
-                **estimator_assumptions}
+                           **estimator_assumptions}
 
-        symbolic_estimand = RealizedEstimand(estimand, estimator_name="Wald Estimator")
+        symbolic_estimand = RealizedEstimand(estimand,
+                                             estimator_name="Wald Estimator")
         symbolic_estimand.update_assumptions(sym_assumptions)
         symbolic_estimand.update_estimand_expression(sym_effect)
         return symbolic_estimand
-

--- a/dowhy/causal_estimators/linear_regression_estimator.py
+++ b/dowhy/causal_estimators/linear_regression_estimator.py
@@ -1,11 +1,11 @@
 import numpy as np
-import pandas as pd
 from sklearn import linear_model
 
-from dowhy.causal_estimator import CausalEstimator, CausalEstimate
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
+
 
 class LinearRegressionEstimator(CausalEstimator):
-
     """Compute effect of treatment using linear regression.
 
     The coefficient of the treatment variable in the regression model is
@@ -16,7 +16,8 @@ class LinearRegressionEstimator(CausalEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.logger.debug("Back-door variables used:" + ",".join(self._target_estimand.backdoor_variables))
+        self.logger.debug("Back-door variables used:" +
+                          ",".join(self._target_estimand.backdoor_variables))
         self._observed_common_causes_names = self._target_estimand.backdoor_variables
         self._observed_common_causes = self._data[self._observed_common_causes_names]
         self.logger.info("INFO: Using Linear Regression Estimator")
@@ -25,26 +26,21 @@ class LinearRegressionEstimator(CausalEstimator):
 
     def _estimate_effect(self):
         treatment_2d = self._treatment.values.reshape(len(self._treatment), -1)
-        #print(treatment_2d)
         features = np.concatenate((treatment_2d, self._observed_common_causes),
-                axis=1)
-        #print(features[0:5])
-        #print(self._outcome[0:5])
+                                  axis=1)
         model = linear_model.LinearRegression()
         model.fit(features, self._outcome)
         coefficients = model.coef_
-        self.logger.debug("Coefficients of the fitted linear model: " + ",".join(map(str,coefficients)))
-        estimate = CausalEstimate(estimate= coefficients[0],
-                target_estimand=self._target_estimand,
-                realized_estimand_expr = self.symbolic_estimator,
-                intercept = model.intercept_)
+        self.logger.debug("Coefficients of the fitted linear model: " +
+                          ",".join(map(str, coefficients)))
+        estimate = CausalEstimate(estimate=coefficients[0],
+                                  target_estimand=self._target_estimand,
+                                  realized_estimand_expr=self.symbolic_estimator,
+                                  intercept=model.intercept_)
         return estimate
 
     def construct_symbolic_estimator(self, estimand):
-        expr = "b: "+ estimand.outcome_variable + "~"
-        var_list = [estimand.treatment_variable,]+estimand.backdoor_variables
+        expr = "b: " + estimand.outcome_variable + "~"
+        var_list = [estimand.treatment_variable, ] + estimand.backdoor_variables
         expr += "+".join(var_list)
         return expr
-
-
-

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -1,18 +1,21 @@
-import numpy as np
 from sklearn import linear_model
 from sklearn.neighbors import NearestNeighbors
-from dowhy.causal_estimator import CausalEstimator, CausalEstimate
+
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
+
 
 class PropensityScoreMatchingEstimator(CausalEstimator):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.logger.debug("Back-door variables used:" + ",".join(self._target_estimand.backdoor_variables))
+        self.logger.debug("Back-door variables used:" +
+                          ",".join(self._target_estimand.backdoor_variables))
         self._observed_common_causes_names = self._target_estimand.backdoor_variables
         self._observed_common_causes = self._data[self._observed_common_causes_names]
         self.logger.info("INFO: Using Propensity Score Matching Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
         self.logger.info(self.symbolic_estimator)
-
 
     def _estimate_effect(self):
         psmodel = linear_model.LinearRegression()
@@ -20,11 +23,14 @@ class PropensityScoreMatchingEstimator(CausalEstimator):
         self._data['ps'] = psmodel.predict(self._observed_common_causes)
 
         # this assumes a binary treatment regime
-        treated = self._data.loc[self._data[self._treatment_name]==1]
-        control = self._data.loc[self._data[self._treatment_name]==0]
+        treated = self._data.loc[self._data[self._treatment_name] == 1]
+        control = self._data.loc[self._data[self._treatment_name] == 0]
 
-        controlNeighbors = NearestNeighbors(n_neighbors=1, algorithm='ball_tree').fit(control['ps'].values.reshape(-1,1))
-        distances, indices = controlNeighbors.kneighbors(treated['ps'].values.reshape(-1,1))
+        controlNeighbors = (
+            NearestNeighbors(n_neighbors=1, algorithm='ball_tree')
+            .fit(control['ps'].values.reshape(-1, 1))
+        )
+        distances, indices = controlNeighbors.kneighbors(treated['ps'].values.reshape(-1, 1))
 
         # TODO remove neighbors that are more than a given radius apart
 
@@ -38,17 +44,14 @@ class PropensityScoreMatchingEstimator(CausalEstimator):
 
         ate /= numtreatedunits
 
-        estimate = CausalEstimate(estimate= ate,
-                target_estimand=self._target_estimand,
-                realized_estimand_expr = self.symbolic_estimator)
+        estimate = CausalEstimate(estimate=ate,
+                                  target_estimand=self._target_estimand,
+                                  realized_estimand_expr=self.symbolic_estimator)
         return estimate
 
-
     def construct_symbolic_estimator(self, estimand):
-        expr = "b: "+ estimand.outcome_variable + "~"
+        expr = "b: " + estimand.outcome_variable + "~"
         # TODO -- fix: we are actually conditioning on positive treatment (d=1)
-        var_list = [estimand.treatment_variable,]+estimand.backdoor_variables
+        var_list = [estimand.treatment_variable, ] + estimand.backdoor_variables
         expr += "+".join(var_list)
         return expr
-
-

--- a/dowhy/causal_estimators/propensity_score_stratification_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_stratification_estimator.py
@@ -1,7 +1,8 @@
-import numpy as np
 from sklearn import linear_model
-from sklearn.neighbors import NearestNeighbors
-from dowhy.causal_estimator import CausalEstimator, CausalEstimate
+
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
+
 
 class PropensityScoreStratificationEstimator(CausalEstimator):
     """ Estimate effect of treatment by stratifying the data into bins with
@@ -9,16 +10,18 @@ class PropensityScoreStratificationEstimator(CausalEstimator):
 
     Straightforward application of the back-door criterion.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.logger.debug("Back-door variables used:" + ",".join(self._target_estimand.backdoor_variables))
+        self.logger.debug("Back-door variables used:" +
+                          ",".join(self._target_estimand.backdoor_variables))
         self._observed_common_causes_names = self._target_estimand.backdoor_variables
         self._observed_common_causes = self._data[self._observed_common_causes_names]
         self.logger.info("INFO: Using Propensity Score Stratification Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
         self.logger.info(self.symbolic_estimator)
 
-        self.numStrata = 50;
+        self.numStrata = 50
         self.clippingThreshold = 10
 
     def _estimate_effect(self):
@@ -29,23 +32,33 @@ class PropensityScoreStratificationEstimator(CausalEstimator):
         # sort the dataframe by propensity score
         # create a column 'strata' for each element that marks what strata it belongs to
         numrows = self._data[self._outcome_name].shape[0]
-        self._data['strata'] = ((self._data['ps'].rank(ascending=True) / numrows) * self.numStrata).round(0)
+        self._data['strata'] = (
+            (self._data['ps'].rank(ascending=True) / numrows) * self.numStrata
+        ).round(0)
 
         # for each strata, count how many treated and control units there are
         # throw away strata that have insufficient treatment or control
-        #print("before clipping, here is the distribution of treatment and control per strata")
-        #print(self._data.groupby(['strata',self._treatment_name])[self._outcome_name].count())
+        # print("before clipping, here is the distribution of treatment and control per strata")
+        # print(self._data.groupby(['strata',self._treatment_name])[self._outcome_name].count())
 
         self._data['dbar'] = 1 - self._data[self._treatment_name]
         self._data['d_y'] = self._data[self._treatment_name] * self._data[self._outcome_name]
         self._data['dbar_y'] = self._data['dbar'] * self._data[self._outcome_name]
         stratified = self._data.groupby('strata')
-        clipped  = stratified.filter(lambda strata: min(strata.loc[strata[self._treatment_name]==1].shape[0], strata.loc[strata[self._treatment_name]==0].shape[0]) > self.clippingThreshold)
-        #print("after clipping at threshold, now we have:" )
-        #print(clipped.groupby(['strata',self._treatment_name])[self._outcome_name].count())
+        clipped = stratified.filter(
+            lambda strata: min(strata.loc[strata[self._treatment_name] == 1].shape[0],
+                               strata.loc[strata[self._treatment_name] == 0].shape[0]) > self.clippingThreshold
+        )
+        # print("after clipping at threshold, now we have:" )
+        # print(clipped.groupby(['strata',self._treatment_name])[self._outcome_name].count())
 
         # sum weighted outcomes over all strata  (weight by treated population)
-        weightedoutcomes = clipped.groupby('strata').agg({self._treatment_name:['sum'], 'dbar':['sum'], 'd_y':['sum'], 'dbar_y':['sum']})
+        weightedoutcomes = clipped.groupby('strata').agg({
+            self._treatment_name: ['sum'],
+            'dbar': ['sum'],
+            'd_y': ['sum'],
+            'dbar_y': ['sum']
+        })
         weightedoutcomes.columns = ["_".join(x) for x in weightedoutcomes.columns.ravel()]
         treatment_sum_name = self._treatment_name + "_sum"
 
@@ -58,15 +71,14 @@ class PropensityScoreStratificationEstimator(CausalEstimator):
 
         # TODO - how can we add additional information into the returned estimate?
         #        such as how much clipping was done, or per-strata info for debugging?
-        estimate = CausalEstimate(estimate= ate,
-                target_estimand=self._target_estimand,
-                realized_estimand_expr = self.symbolic_estimator)
+        estimate = CausalEstimate(estimate=ate,
+                                  target_estimand=self._target_estimand,
+                                  realized_estimand_expr=self.symbolic_estimator)
         return estimate
 
     def construct_symbolic_estimator(self, estimand):
-        expr = "b: "+ estimand.outcome_variable + "~"
+        expr = "b: " + estimand.outcome_variable + "~"
         # TODO -- fix: we are actually conditioning on positive treatment (d=1)
-        var_list = [estimand.treatment_variable,]+estimand.backdoor_variables
+        var_list = [estimand.treatment_variable, ] + estimand.backdoor_variables
         expr += "+".join(var_list)
         return expr
-

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -1,7 +1,9 @@
 import numpy as np
 from sklearn import linear_model
-from sklearn.neighbors import NearestNeighbors
-from dowhy.causal_estimator import CausalEstimator, CausalEstimate
+
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
+
 
 class PropensityScoreWeightingEstimator(CausalEstimator):
     """ Estimate effect of treatment by stratifying the data into bins with
@@ -9,15 +11,17 @@ class PropensityScoreWeightingEstimator(CausalEstimator):
 
     Straightforward application of the back-door criterion.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.logger.debug("Back-door variables used:" + ",".join(self._target_estimand.backdoor_variables))
+        self.logger.debug("Back-door variables used:" +
+                          ",".join(self._target_estimand.backdoor_variables))
         self._observed_common_causes_names = self._target_estimand.backdoor_variables
         self._observed_common_causes = self._data[self._observed_common_causes_names]
         self.logger.info("INFO: Using Propensity Score Weighting Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
         self.logger.info(self.symbolic_estimator)
-        self.weighting_scheme = 'ips_weight' # 'itps_weight' 'ips_weight' 'nips_weight'
+        self.weighting_scheme = 'ips_weight'  # 'itps_weight' 'ips_weight' 'nips_weight'
         self.min_ps_score = 0.05
         self.max_ps_score = 0.95
 
@@ -35,7 +39,10 @@ class PropensityScoreWeightingEstimator(CausalEstimator):
         # icps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all control units)
         # itps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all treatment units)
 
-        self._data['ips_weight'] = (self._data[self._treatment_name] / self._data['ps']) + ((1 - self._data[self._treatment_name]) / (1 - self._data['ps']))
+        self._data['ips_weight'] = (
+            self._data[self._treatment_name] / self._data['ps'] +
+            (1 - self._data[self._treatment_name]) / (1 - self._data['ps'])
+        )
         ips_sum = self._data['ips_weight'].sum()
         self._data['nips_weight'] = self._data['ips_weight'] / ips_sum
 
@@ -46,21 +53,28 @@ class PropensityScoreWeightingEstimator(CausalEstimator):
         self._data['itps_weight'] = self._data['ips2'] / control_ips_sum
         self._data['icps_weight'] = self._data['ips2'] / control_ips_sum
 
-        self._data['d_y'] = self._data[self.weighting_scheme] * self._data[self._treatment_name] * self._data[self._outcome_name]
-        self._data['dbar_y'] = self._data[self.weighting_scheme] * (1 - self._data[self._treatment_name]) * self._data[self._outcome_name]
+        self._data['d_y'] = (
+            self._data[self.weighting_scheme] *
+            self._data[self._treatment_name] *
+            self._data[self._outcome_name]
+        )
+        self._data['dbar_y'] = (
+            self._data[self.weighting_scheme] *
+            (1 - self._data[self._treatment_name]) *
+            self._data[self._outcome_name]
+        )
 
         ate = self._data['d_y'].sum() - self._data['dbar_y'].sum()
 
         # TODO - how can we add additional information into the returned estimate?
-        estimate = CausalEstimate(estimate= ate,
-                target_estimand=self._target_estimand,
-                realized_estimand_expr = self.symbolic_estimator)
+        estimate = CausalEstimate(estimate=ate,
+                                  target_estimand=self._target_estimand,
+                                  realized_estimand_expr=self.symbolic_estimator)
         return estimate
 
     def construct_symbolic_estimator(self, estimand):
-        expr = "b: "+ estimand.outcome_variable + "~"
+        expr = "b: " + estimand.outcome_variable + "~"
         # TODO -- fix: we are actually conditioning on positive treatment (d=1)
-        var_list = [estimand.treatment_variable,]+estimand.backdoor_variables
+        var_list = [estimand.treatment_variable, ] + estimand.backdoor_variables
         expr += "+".join(var_list)
         return expr
-

--- a/dowhy/causal_estimators/regression_discontinuity_estimator.py
+++ b/dowhy/causal_estimators/regression_discontinuity_estimator.py
@@ -1,13 +1,11 @@
 import numpy as np
 import pandas as pd
-import sympy as sp
-import sympy.stats as spstats
 
-from dowhy.causal_estimator import CausalEstimator, CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
 from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
 
-class RegressionDiscontinuityEstimator(CausalEstimator):
 
+class RegressionDiscontinuityEstimator(CausalEstimator):
     """Compute effect of treatment using the regression discontinuity method.
 
     Estimates effect by transforming the problem to an instrumental variables
@@ -25,19 +23,23 @@ class RegressionDiscontinuityEstimator(CausalEstimator):
     def _estimate_effect(self):
         upper_limit = self.rd_threshold_value + self.rd_bandwidth
         lower_limit = self.rd_threshold_value - self.rd_bandwidth
-        rows_filter = np.s_[(self.rd_variable >= lower_limit) &(self.rd_variable <= upper_limit)]
+        rows_filter = np.s_[(self.rd_variable >= lower_limit) & (self.rd_variable <= upper_limit)]
         local_rd_variable = self.rd_variable[rows_filter]
         local_treatment_variable = self._treatment[rows_filter]
         local_outcome_variable = self._outcome[rows_filter]
-        local_df = pd.DataFrame(data= {
+        local_df = pd.DataFrame(data={
             'local_rd_variable': local_rd_variable,
             'local_treatment': local_treatment_variable,
-            'local_outcome': local_outcome_variable})
-        iv_estimator = InstrumentalVariableEstimator(local_df,
-                self._target_estimand,
-                'local_treatment', 'local_outcome',
-                test_significance = self._significance_test,
-                params = {'iv_instrument_name': 'local_rd_variable'})
+            'local_outcome': local_outcome_variable
+        })
+        iv_estimator = InstrumentalVariableEstimator(
+            local_df,
+            self._target_estimand,
+            'local_treatment',
+            'local_outcome',
+            test_significance=self._significance_test,
+            params={'iv_instrument_name': 'local_rd_variable'}
+        )
         est = iv_estimator.estimate_effect()
         return est
 

--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -1,23 +1,27 @@
 import logging
-import pygraphviz as pgv
+
 import networkx as nx
+import pygraphviz as pgv
+
 
 class CausalGraph:
+
     def __init__(self,
                  treatment_name, outcome_name,
-                 graph = None,
-                 common_cause_names = None,
-                 instrument_names = None,
+                 graph=None,
+                 common_cause_names=None,
+                 instrument_names=None,
                  observed_node_names=None):
         self.treatment_name = treatment_name
         self.outcome_name = outcome_name
-        self.fullname = str.join("_",
-                [self.treatment_name, self.outcome_name,
-                    str(common_cause_names),
-                    str(instrument_names)])
+        self.fullname = "_".join([self.treatment_name,
+                                  self.outcome_name,
+                                  str(common_cause_names),
+                                  str(instrument_names)])
         if graph is None:
             self._graph = pgv.AGraph(strict=True, directed=True)
-            self._graph = self.build_graph(common_cause_names, instrument_names)
+            self._graph = self.build_graph(common_cause_names,
+                                           instrument_names)
         else:
             self._graph = pgv.AGraph(graph, strict=True, directed=True)
 
@@ -27,10 +31,7 @@ class CausalGraph:
         self.logger = logging.getLogger(__name__)
 
     def view_graph(self, layout="dot"):
-        #print(self._graph)
         agraph = nx.drawing.nx_agraph.to_agraph(self._graph)
-        #print(dict(agraph.get_node('U').attr))
-        #agraph.draw(self.fullname+".png", prog="neato")
         agraph.draw("causal_model.png", format="png", prog=layout)
 
     def build_graph(self, common_cause_names, instrument_names):
@@ -42,14 +43,14 @@ class CausalGraph:
         if common_cause_names is not None:
             for node_name in common_cause_names:
                 self._graph.add_node(node_name, observed="yes")
-                self._graph.add_edge(node_name,self.treatment_name)
-                self._graph.add_edge(node_name,self.outcome_name)
+                self._graph.add_edge(node_name, self.treatment_name)
+                self._graph.add_edge(node_name, self.outcome_name)
         # Adding instruments
         if instrument_names is not None:
             for node_name in instrument_names:
                 self._graph.add_node(node_name, observed="yes")
-                self._graph.add_edge(node_name,self.treatment_name)
-        return(self._graph)
+                self._graph.add_edge(node_name, self.treatment_name)
+        return self._graph
 
     def add_node_attributes(self, observed_node_names):
         for node_name in self._graph:
@@ -61,21 +62,22 @@ class CausalGraph:
 
     def add_unobserved_common_cause(self, observed_node_names):
         # Adding unobserved confounders
-        current_common_causes = self.get_common_causes(self.treatment_name, self.outcome_name)
+        current_common_causes = self.get_common_causes(self.treatment_name,
+                                                       self.outcome_name)
         create_new_common_cause = True
         for node_name in current_common_causes:
-            if self._graph.nodes[node_name]["observed"]=="no":
+            if self._graph.nodes[node_name]["observed"] == "no":
                 create_new_common_cause = False
 
         if create_new_common_cause:
             uc_label = "Unobserved Confounders"
             self._graph.add_node('U', label=uc_label)
-            self._graph.add_edge('U',self.treatment_name)
-            self._graph.add_edge('U',self.outcome_name)
+            self._graph.add_edge('U', self.treatment_name)
+            self._graph.add_edge('U', self.outcome_name)
         return self._graph
 
     def do_surgery(self, node_names, remove_outgoing_edges=False,
-            remove_incoming_edges=False):
+                   remove_incoming_edges=False):
         new_graph = self._graph.copy()
         for node_name in node_names:
             if remove_outgoing_edges:
@@ -88,17 +90,13 @@ class CausalGraph:
                 new_graph.remove_edges_from(edges_bunch)
         return new_graph
 
-
-
     def get_common_causes(self, node1, node2):
-         causes_node1 = self.get_ancestors(node1)
-         causes_node2 = self.get_ancestors(node2)
-         return list(causes_node1.intersection(causes_node2))
-
+        causes_node1 = self.get_ancestors(node1)
+        causes_node2 = self.get_ancestors(node2)
+        return list(causes_node1.intersection(causes_node2))
 
     def get_parents(self, node_name):
         return set(self._graph.predecessors(node_name))
-
 
     def get_ancestors(self, node_name):
         return set(nx.ancestors(self._graph, node_name))
@@ -109,7 +107,7 @@ class CausalGraph:
     def all_observed(self, node_names):
         agraph = nx.drawing.nx_agraph.to_agraph(self._graph)
         for node_name in node_names:
-            if agraph.get_node(node_name).attr["observed"]!="yes":
+            if agraph.get_node(node_name).attr["observed"] != "yes":
                 return False
 
         return True
@@ -118,27 +116,28 @@ class CausalGraph:
         observed_node_names = list()
         agraph = nx.drawing.nx_agraph.to_agraph(self._graph)
         for node_name in node_names:
-            if agraph.get_node(node_name).attr["observed"]=="yes":
+            if agraph.get_node(node_name).attr["observed"] == "yes":
                 observed_node_names.append(node_name)
 
         return observed_node_names
 
     def get_instruments(self, treatment_node, outcome_node):
         parents_treatment = self.get_parents(treatment_node)
-        g_no_parents_treatment = self.do_surgery([treatment_node,],
-                remove_incoming_edges=True)
+        g_no_parents_treatment = self.do_surgery([treatment_node, ],
+                                                 remove_incoming_edges=True)
         ancestors_outcome = nx.ancestors(g_no_parents_treatment, outcome_node)
 
-        #Exclusion
+        # Exclusion
         candidate_instruments = parents_treatment.difference(ancestors_outcome)
-        self.logger.debug("Candidate instruments after exclusion"+str(candidate_instruments))
+        self.logger.debug("Candidate instruments after exclusion %s",
+                          candidate_instruments)
         # As-if-random setup
-        children_causes_outcome = [nx.descendants(g_no_parents_treatment, v) for
-                v in ancestors_outcome]
-        children_causes_outcome = set([item for sublist in children_causes_outcome
-            for item in sublist])
+        children_causes_outcome = [nx.descendants(g_no_parents_treatment, v)
+                                   for v in ancestors_outcome]
+        children_causes_outcome = set([item
+                                       for sublist in children_causes_outcome
+                                       for item in sublist])
 
         # As-if-random
         instruments = candidate_instruments.difference(children_causes_outcome)
         return list(instruments)
-

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -1,9 +1,13 @@
 import logging
+
 import sympy as sp
 import sympy.stats as spstats
+
 import dowhy.utils.cli_helpers as cli
 
+
 class CausalIdentifier:
+
     def __init__(self, graph, estimand_type):
         self._graph = graph
         self.estimand_type = estimand_type
@@ -21,95 +25,114 @@ class CausalIdentifier:
             print("All common causes are observed. Causal effect can be identified.")
         else:
             print("There are unobserved common causes. Causal effect cannot be identified.")
-            cli.query_yes_no("WARN: Do you want to continue by ignoring these unobserved confounders?", default=None)
+            cli.query_yes_no(
+                "WARN: Do you want to continue by ignoring these unobserved confounders?",
+                default=None
+            )
         observed_common_causes = self._graph.filter_unobserved_variables(common_causes)
         observed_common_causes = list(observed_common_causes)
 
-        backdoor_estimand_expr = self.construct_backdoor_estimand(self.estimand_type, self._graph.treatment_name,
-                self._graph.outcome_name, observed_common_causes)
+        backdoor_estimand_expr = self.construct_backdoor_estimand(
+            self.estimand_type, self._graph.treatment_name,
+            self._graph.outcome_name, observed_common_causes
+        )
 
         self.logger.debug("Identified expression = " + str(backdoor_estimand_expr))
         estimands_dict["backdoor"] = backdoor_estimand_expr
 
         # Now checking if there is also a valid iv estimand
         instrument_names = self._graph.get_instruments(self.treatment_name,
-                self.outcome_name)
+                                                       self.outcome_name)
         self.logger.info("Instrumental variables for treatment and outcome:" +
-                str(instrument_names))
+                         str(instrument_names))
         if len(instrument_names) > 0:
-            iv_estimand_expr = self.construct_iv_estimand(self.estimand_type,
-                    self._graph.treatment_name,
-                    self._graph.outcome_name,
-                    instrument_names)
+            iv_estimand_expr = self.construct_iv_estimand(
+                self.estimand_type,
+                self._graph.treatment_name,
+                self._graph.outcome_name,
+                instrument_names
+            )
             self.logger.debug("Identified expression = " + str(iv_estimand_expr))
             estimands_dict["iv"] = iv_estimand_expr
         else:
             estimands_dict["iv"] = None
 
         estimand = IdentifiedEstimand(
-                treatment_variable = self._graph.treatment_name,
-                outcome_variable = self._graph.outcome_name,
-                estimand_type= self.estimand_type,
-                estimands = estimands_dict,
-                backdoor_variables = observed_common_causes,
-                instrumental_variables = instrument_names)
+            treatment_variable=self._graph.treatment_name,
+            outcome_variable=self._graph.outcome_name,
+            estimand_type=self.estimand_type,
+            estimands=estimands_dict,
+            backdoor_variables=observed_common_causes,
+            instrumental_variables=instrument_names
+        )
         return estimand
 
-    def construct_backdoor_estimand(self, estimand_type, treatment_name, outcome_name, common_causes):
+    def construct_backdoor_estimand(self, estimand_type, treatment_name,
+                                    outcome_name, common_causes):
         # TODO: outputs string for now, but ideally should do symbolic
         # expressions Mon 19 Feb 2018 04:54:17 PM DST
         expr = None
-        if estimand_type=="ate":
-            num_expr_str= outcome_name + "|"
+        if estimand_type == "ate":
+            num_expr_str = outcome_name + "|"
             num_expr_str += ",".join(common_causes)
-            expr = "d("+ num_expr_str+")/d" + treatment_name
+            expr = "d(" + num_expr_str + ")/d" + treatment_name
             sym_mu = sp.Symbol("mu")
             sym_sigma = sp.Symbol("sigma", positive=True)
             sym_outcome = spstats.Normal(num_expr_str, sym_mu, sym_sigma)
-            #sym_common_causes = [sp.stats.Normal(common_cause, sym_mu, sym_sigma) for common_cause in common_causes]
+            # sym_common_causes = [sp.stats.Normal(common_cause, sym_mu, sym_sigma) for common_cause in common_causes]
             sym_treatment = sp.Symbol(treatment_name)
             sym_conditional_outcome = spstats.Expectation(sym_outcome)
             sym_effect = sp.Derivative(sym_conditional_outcome, sym_treatment)
 
-            sym_assumptions = {'Unconfoundedness': (u"If U\N{RIGHTWARDS ARROW}{0} and U\N{RIGHTWARDS ARROW}{1}"
-                    " then P({1}|{0},{2},U) = P({1}|{0},{2})").format(treatment_name, outcome_name,
-            ",".join(common_causes))}
+            sym_assumptions = {
+                'Unconfoundedness': (
+                    u"If U\N{RIGHTWARDS ARROW}{0} and U\N{RIGHTWARDS ARROW}{1}"
+                    " then P({1}|{0},{2},U) = P({1}|{0},{2})"
+                ).format(treatment_name, outcome_name, ",".join(common_causes))
+            }
 
         estimand = {
-                'estimand': sym_effect,
-                'assumptions': sym_assumptions
-                }
+            'estimand': sym_effect,
+            'assumptions': sym_assumptions
+        }
         return estimand
 
     def construct_iv_estimand(self, estimand_type, treatment_name,
-            outcome_name, instrument_names):
+                              outcome_name, instrument_names):
         expr = None
         if estimand_type == "ate":
-            sym_outcome = spstats.Normal(outcome_name,0,1)
+            sym_outcome = spstats.Normal(outcome_name, 0, 1)
             sym_treatment = spstats.Normal(treatment_name, 0, 1)
-            sym_instrument = sp.Symbol(instrument_names[0])#",".join(instrument_names))
+            sym_instrument = sp.Symbol(instrument_names[0])  # ",".join(instrument_names))
             sym_outcome_derivative = sp.Derivative(sym_outcome, sym_instrument)
-            sym_treatment_derivative =  sp.Derivative(sym_treatment, sym_instrument)
-            sym_effect = spstats.Expectation(sym_outcome_derivative/sym_treatment_derivative)
+            sym_treatment_derivative = sp.Derivative(sym_treatment, sym_instrument)
+            sym_effect = spstats.Expectation(sym_outcome_derivative / sym_treatment_derivative)
             sym_assumptions = {
-                    "As-if-random": u"If U\N{RIGHTWARDS ARROW}\N{RIGHTWARDS ARROW}{0} then \N{NOT SIGN}(U \N{RIGHTWARDS ARROW}\N{RIGHTWARDS ARROW}{1})""".format(outcome_name,
-                        ",".join(instrument_names)),
-                    "Exclusion": u"If we remove {{{0}}}\N{RIGHTWARDS ARROW}{1}, then \N{NOT SIGN}({0}\N{RIGHTWARDS ARROW}{2})""".format(",".join(instrument_names),
-                        treatment_name, outcome_name)
-                    }
+                "As-if-random": (
+                    "If U\N{RIGHTWARDS ARROW}\N{RIGHTWARDS ARROW}{0} then "
+                    "\N{NOT SIGN}(U \N{RIGHTWARDS ARROW}\N{RIGHTWARDS ARROW}{1})"
+                ).format(outcome_name, ",".join(instrument_names)),
+                "Exclusion": (
+                    u"If we remove {{{0}}}\N{RIGHTWARDS ARROW}{1}, then "
+                    u"\N{NOT SIGN}({0}\N{RIGHTWARDS ARROW}{2})"
+                ).format(",".join(instrument_names), treatment_name,
+                         outcome_name)
+            }
 
         estimand = {
-                'estimand': sym_effect,
-                'assumptions': sym_assumptions
-                }
+            'estimand': sym_effect,
+            'assumptions': sym_assumptions
+        }
         return estimand
 
+
 class IdentifiedEstimand:
+
     def __init__(self, treatment_variable, outcome_variable,
-            estimand_type=None, estimands=None,
-            backdoor_variables=None, instrumental_variables = None):
+                 estimand_type=None, estimands=None,
+                 backdoor_variables=None, instrumental_variables=None):
         self.treatment_variable = treatment_variable
-        self.outcome_variable =  outcome_variable
+        self.outcome_variable = outcome_variable
         self.backdoor_variables = backdoor_variables
         self.instrumental_variables = instrumental_variables
         self.estimand_type = estimand_type
@@ -133,6 +156,6 @@ class IdentifiedEstimand:
                 j = 1
                 for ass_name, ass_str in v["assumptions"].items():
                     s += "Estimand assumption {0}, {1}: {2}\n".format(j, ass_name, ass_str)
-                    j +=1
+                    j += 1
             i += 1
         return s

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -1,6 +1,8 @@
 import logging
 
+
 class CausalRefuter:
+
     def __init__(self, data, identified_estimand, estimate, **kwargs):
         self._data = data
         self._target_estimand = identified_estimand
@@ -9,11 +11,15 @@ class CausalRefuter:
         self._outcome_name = self._target_estimand.outcome_variable
         self.logger = logging.getLogger(__name__)
 
+
 class CausalRefutation:
+
     def __init__(self, estimated_effect, new_effect, refutation_type):
-        self.estimated_effect =  estimated_effect,
+        self.estimated_effect = estimated_effect,
         self.new_effect = new_effect,
-        self.refutation_type=refutation_type
+        self.refutation_type = refutation_type
 
     def __str__(self):
-        return "{0}\nEstimated effect:{1}\nNew effect:{2}\n".format(self.refutation_type, self.estimated_effect, self.new_effect)
+        return "{0}\nEstimated effect:{1}\nNew effect:{2}\n".format(
+            self.refutation_type, self.estimated_effect, self.new_effect
+        )

--- a/dowhy/causal_refuters/__init__.py
+++ b/dowhy/causal_refuters/__init__.py
@@ -1,15 +1,17 @@
 import string
 from importlib import import_module
+
 from dowhy.causal_refuter import CausalRefuter
+
 
 def get_class_object(method_name, *args, **kwargs):
     # from https://www.bnmetrics.com/blog/factory-pattern-in-python3-simple-version
     try:
         module_name = method_name
-        class_name=string.capwords(method_name, "_").replace("_", "")
+        class_name = string.capwords(method_name, "_").replace("_", "")
 
         refuter_module = import_module('.' + module_name,
-                package = "dowhy.causal_refuters")
+                                       package="dowhy.causal_refuters")
         refuter_class = getattr(refuter_module, class_name)
         assert issubclass(refuter_class, CausalRefuter)
 

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -1,25 +1,28 @@
-import numpy as np
-
 from dowhy.causal_refuter import CausalRefuter, CausalRefutation
-from dowhy.causal_identifier import IdentifiedEstimand
+
 
 class DataSubsetRefuter(CausalRefuter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._subset_fraction=kwargs["subset_fraction"]
+        self._subset_fraction = kwargs["subset_fraction"]
 
     def refute_estimate(self):
         new_data = self._data.sample(frac=self._subset_fraction)
 
         estimator_class = self._estimate.params['estimator_class']
         identified_estimand = self._target_estimand
-        new_estimator  = estimator_class(
-                new_data,
-                identified_estimand,
-                self._treatment_name, self._outcome_name,
-                test_significance = None)
+        new_estimator = estimator_class(
+            new_data,
+            identified_estimand,
+            self._treatment_name,
+            self._outcome_name,
+            test_significance=None
+        )
         new_effect = new_estimator.estimate_effect()
-        refute = CausalRefutation(self._estimate.value, new_effect.value,
-                refutation_type = "Refute: Use a subset of data")
-        return(refute)
+        refute = CausalRefutation(
+            self._estimate.value,
+            new_effect.value,
+            refutation_type="Refute: Use a subset of data"
+        )
+        return refute

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -1,19 +1,21 @@
-import numpy as np
 import copy
 
-from dowhy.causal_refuter import CausalRefuter, CausalRefutation
-from dowhy.causal_identifier import IdentifiedEstimand
+import numpy as np
+
+from dowhy.causal_refuter import CausalRefutation
+from dowhy.causal_refuter import CausalRefuter
+
 
 class PlaceboTreatmentRefuter(CausalRefuter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._placebo_type=kwargs["placebo_type"]
+        self._placebo_type = kwargs["placebo_type"]
 
     def refute_estimate(self):
         num_rows = self._data.shape[0]
         if self._placebo_type == "permute":
-            new_treatment =self._data[self._treatment_name].sample(frac=1).values
+            new_treatment = self._data[self._treatment_name].sample(frac=1).values
         else:
             new_treatment = np.random.randn(num_rows)
         new_data = self._data.assign(placebo=new_treatment)
@@ -23,12 +25,13 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         identified_estimand = copy.deepcopy(self._target_estimand)
         identified_estimand.treatment_variable = "placebo"
 
-        new_estimator  = estimator_class(
-                new_data,
-                identified_estimand,
-                "placebo", self._outcome_name,
-                test_significance=None)
+        new_estimator = estimator_class(
+            new_data,
+            identified_estimand,
+            "placebo", self._outcome_name,
+            test_significance=None
+        )
         new_effect = new_estimator.estimate_effect()
         refute = CausalRefutation(self._estimate.value, new_effect.value,
-                refutation_type = "Refute: Use a Placebo Treatment")
-        return(refute)
+                                  refutation_type="Refute: Use a Placebo Treatment")
+        return refute

--- a/dowhy/causal_refuters/random_common_cause.py
+++ b/dowhy/causal_refuters/random_common_cause.py
@@ -1,8 +1,10 @@
-import numpy as np
 import copy
 
-from dowhy.causal_refuter import CausalRefuter, CausalRefutation
-from dowhy.causal_identifier import IdentifiedEstimand
+import numpy as np
+
+from dowhy.causal_refuter import CausalRefutation
+from dowhy.causal_refuter import CausalRefuter
+
 
 class RandomCommonCause(CausalRefuter):
     def __init__(self, *args, **kwargs):
@@ -12,24 +14,21 @@ class RandomCommonCause(CausalRefuter):
         num_rows = self._data.shape[0]
         new_data = self._data.assign(w_random=np.random.randn(num_rows))
         self.logger.debug(new_data[0:10])
-        new_backdoor_variables = self._target_estimand.backdoor_variables +['w_random']
+        new_backdoor_variables = self._target_estimand.backdoor_variables + ['w_random']
         estimator_class = self._estimate.params['estimator_class']
         identified_estimand = copy.deepcopy(self._target_estimand)
         identified_estimand.backdoor_variables = new_backdoor_variables
-        #identified_estimand = IdentifiedEstimand(
+        # identified_estimand = IdentifiedEstimand(
         #        treatment_variable = self._treatment_name,
         #        outcome_variable = self._outcome_name,
         #        backdoor_variables = new_backdoor_variables)#self._target_estimand.backdoor_variables)#new_backdoor_variables)
-        new_estimator  = estimator_class(
-                new_data,
-                identified_estimand,
-                self._treatment_name, self._outcome_name,
-                test_significance = None)
+        new_estimator = estimator_class(
+            new_data,
+            identified_estimand,
+            self._treatment_name, self._outcome_name,
+            test_significance=None
+        )
         new_effect = new_estimator.estimate_effect()
         refute = CausalRefutation(self._estimate.value, new_effect.value,
-                refutation_type = "Refute: Add a Random Common Cause")
-        return(refute)
-
-
-
-
+                                  refutation_type="Refute: Add a Random Common Cause")
+        return refute

--- a/dowhy/data_transformer.py
+++ b/dowhy/data_transformer.py
@@ -1,10 +1,8 @@
 class DimensionalityReducer:
+
     def __init__(self, data_array, ndims, **kwargs):
         self._data = data_array
         self._ndims = ndims
 
     def reduce(self, target_dimensions=None):
         pass
-
-
-

--- a/dowhy/data_transformers/pca_reducer.py
+++ b/dowhy/data_transformers/pca_reducer.py
@@ -3,7 +3,9 @@ from sklearn.preprocessing import scale
 
 from dowhy.data_transformer import DimensionalityReducer
 
+
 class PCAReducer(DimensionalityReducer):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._do_standardize = True
@@ -17,6 +19,3 @@ class PCAReducer(DimensionalityReducer):
         pca_model = PCA(n_components=self._ndims)
         reduced_data = pca_model.fit_transform(data)
         return reduced_data
-
-
-

--- a/dowhy/datasets.py
+++ b/dowhy/datasets.py
@@ -1,17 +1,21 @@
+import math
+
 import numpy as np
 import pandas as pd
-import math
 from numpy.random import choice
+
 
 def sigmoid(x):
     return 1 / (1 + math.exp(-x))
 
+
 def stochastically_convert_to_binary(x):
     p = sigmoid(x)
-    return choice([0,1], 1, p=[1-p,p])
+    return choice([0, 1], 1, p=[1-p, p])
 
-def linear_dataset(beta, num_common_causes, num_samples,
-        num_instruments = 0, treatment_is_binary=True):
+
+def linear_dataset(beta, num_common_causes, num_samples, num_instruments=0,
+                   treatment_is_binary=True):
     if num_common_causes > 0:
         range_c1 = beta*0.5
         range_c2 = beta*0.5
@@ -26,26 +30,23 @@ def linear_dataset(beta, num_common_causes, num_samples,
         p = np.random.uniform(0, 1, num_instruments)
         Z = np.zeros((num_samples, num_instruments))
         for i in range(num_instruments):
-            if(i % 2) == 0:
-                Z[:,i] = np.random.binomial(n=1, p=p[i], size=num_samples)
+            if (i % 2) == 0:
+                Z[:, i] = np.random.binomial(n=1, p=p[i], size=num_samples)
             else:
-                Z[:,i] = np.random.uniform(0, 1, size=num_samples)
+                Z[:, i] = np.random.uniform(0, 1, size=num_samples)
         cz = np.random.uniform(0, range_cz, num_instruments)
-
 
     # TODO - test all our methods with random noise added to covariates (instead of the stochastic treatment assignment)
     t = 0
-    if num_common_causes >0:
-        t += X @ c1 #+ np.random.normal(0, 0.01)
+    if num_common_causes > 0:
+        t += X @ c1  # + np.random.normal(0, 0.01)
     if num_instruments > 0:
         t += Z @ cz
     if treatment_is_binary:
         t = np.vectorize(stochastically_convert_to_binary)(t)
 
-    y = X @ c2 + beta*t #+ np.random.normal(0,0.01)
-    #print(c1)
-    #print(c2)
-    data = np.column_stack((t,y))
+    y = X @ c2 + beta*t  # + np.random.normal(0,0.01)
+    data = np.column_stack((t, y))
     if num_common_causes > 0:
         data = np.column_stack((X, data))
     if num_instruments > 0:
@@ -53,33 +54,34 @@ def linear_dataset(beta, num_common_causes, num_samples,
 
     treatment = "v"
     outcome = "y"
-    common_causes = [("X"+str(i)) for i in range(0, num_common_causes)]
+    common_causes = [("X" + str(i)) for i in range(0, num_common_causes)]
     ate = beta
-    instruments =  [("Z"+str(i)) for i in range(0, num_instruments)]
+    instruments = [("Z" + str(i)) for i in range(0, num_instruments)]
     other_variables = None
     col_names = instruments + common_causes + [treatment, outcome]
-    data = pd.DataFrame(data,
-            columns = col_names)
+    data = pd.DataFrame(data, columns=col_names)
     dot_graph = ('digraph {{ {0} ->{1};'
-                ' U[label="Unobserved Confounders"];'
-                ' U->{0}; U->{1};'
-                ).format(treatment, outcome)
-    dot_graph = dot_graph + " ".join([v+"-> "+treatment+";" for v in common_causes])
-    dot_graph = dot_graph + " ".join([v+"-> "+outcome+";" for v in common_causes])
-    dot_graph = dot_graph + " ".join([v+"-> "+treatment+";" for v in instruments])
-    dot_graph = dot_graph +"}"
+                 ' U[label="Unobserved Confounders"];'
+                 ' U->{0}; U->{1};'
+                 ).format(treatment, outcome)
+    dot_graph = dot_graph + " ".join([v + "-> " + treatment + ";" for v in common_causes])
+    dot_graph = dot_graph + " ".join([v + "-> " + outcome + ";" for v in common_causes])
+    dot_graph = dot_graph + " ".join([v + "-> " + treatment + ";" for v in instruments])
+    dot_graph = dot_graph + "}"
 
     ret_dict = {
-            "df": data,
-            "treatment_name": treatment,
-            "outcome_name": outcome,
-            "common_causes_names": common_causes,
-            "instrument_names": instruments,
-            "dot_graph":dot_graph,
-            "ate": beta}
-    return(ret_dict)
+        "df": data,
+        "treatment_name": treatment,
+        "outcome_name": outcome,
+        "common_causes_names": common_causes,
+        "instrument_names": instruments,
+        "dot_graph": dot_graph,
+        "ate": ate
+    }
+    return ret_dict
 
-def xy_dataset(num_samples, effect = True, sd_error=1):
+
+def xy_dataset(num_samples, effect=True, sd_error=1):
     treatment = 'Treatment'
     outcome = 'Outcome'
     common_causes = ['w0']
@@ -88,37 +90,34 @@ def xy_dataset(num_samples, effect = True, sd_error=1):
     E2 = np.random.normal(loc=0, scale=sd_error, size=num_samples)
 
     S = np.random.uniform(0, 10, num_samples)
-    T1 = 4- (S-3)*(S-3)
-    T1[S>=5] = 0
-    T2 = (S-7)*(S-7) - 4
-    T2[S<=5] = 0
-    W = T1+T2 # hidden confounder
+    T1 = 4 - (S - 3) * (S - 3)
+    T1[S >= 5] = 0
+    T2 = (S - 7) * (S - 7) - 4
+    T2[S <= 5] = 0
+    W = T1 + T2  # hidden confounder
     if effect:
         U = None
-        V = 6+W + E1
-        Y = 6+ V +W + E2#+ (V-8)*(V-8)
+        V = 6 + W + E1
+        Y = 6 + V + W + E2  # + (V-8)*(V-8)
     else:
-        U = W#np.random.normal(0, 1, num_samples)
-        V = 6+ W + E1
-        Y = 12+ W + W + E2#E2_new
-    #print(Y.shape)
-    #print(V.shape)
+        U = W  # np.random.normal(0, 1, num_samples)
+        V = 6 + W + E1
+        Y = 12 + W + W + E2  # E2_new
     dat = {
         treatment: V,
         outcome: Y,
         common_causes[0]: W,
         time_var: S
-        }
+    }
     data = pd.DataFrame(data=dat)
     ret_dict = {
-            "df": data,
-            "treatment_name": treatment,
-            "outcome_name": outcome,
-            "common_causes_names": common_causes,
-            "time_val": time_var,
-            "instrument_names": None,
-            "dot_graph":None,
-            "ate": None}
-    return(ret_dict)
-
-
+        "df": data,
+        "treatment_name": treatment,
+        "outcome_name": outcome,
+        "common_causes_names": common_causes,
+        "time_val": time_var,
+        "instrument_names": None,
+        "dot_graph": None,
+        "ate": None,
+    }
+    return ret_dict

--- a/dowhy/do_why.py
+++ b/dowhy/do_why.py
@@ -1,29 +1,31 @@
 """ Module containing the main model class for the dowhy package.
 
 """
-import sys
-import pygraphviz as pgv
-import networkx as nx
-import logging
-# To display symbolic math symbols
-from sympy import init_printing
-init_printing()
 
-from dowhy.causal_graph import CausalGraph
-from dowhy.causal_identifier import CausalIdentifier
-from dowhy.causal_estimator import CausalEstimate
+import logging
+
+from sympy import init_printing
+
 import dowhy.causal_estimators as causal_estimators
 import dowhy.causal_refuters as causal_refuters
 import dowhy.utils.cli_helpers as cli
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_graph import CausalGraph
+from dowhy.causal_identifier import CausalIdentifier
 
-class CausalModel(object):
+
+init_printing()  # To display symbolic math symbols
+
+
+class CausalModel:
 
     """Main class for storing the causal model state.
 
     """
 
     def __init__(self, data, treatment, outcome, graph=None,
-            common_causes=None, instruments=None, estimand_type="ate", **kwargs):
+                 common_causes=None, instruments=None, estimand_type="ate",
+                 **kwargs):
         """Initialize data and create a causal graph instance.
 
         Assigns treatment and outcome variables.
@@ -57,46 +59,50 @@ class CausalModel(object):
         self.logger = logging.getLogger(__name__)
 
         if graph is None:
-            self.logger.warn("WARN: Causal Graph not provided. DoWhy will construct a graph based on data inputs.")
+            self.logger.warning("Causal Graph not provided. DoWhy will construct a graph based on data inputs.")
             self._common_causes = common_causes
             self._instruments = instruments
             if common_causes is not None and instruments is not None:
                 self._graph = CausalGraph(
-                        self._treatment,
-                        self._outcome,
-                        common_cause_names=self._common_causes,
-                        instrument_names=self._instruments,
-                        observed_node_names = self._data.columns.tolist())
+                    self._treatment,
+                    self._outcome,
+                    common_cause_names=self._common_causes,
+                    instrument_names=self._instruments,
+                    observed_node_names=self._data.columns.tolist()
+                )
             elif common_causes is not None:
                 self._graph = CausalGraph(
-                        self._treatment,
-                        self._outcome,
-                        common_cause_names=self._common_causes,
-                        observed_node_names = self._data.columns.tolist())
+                    self._treatment,
+                    self._outcome,
+                    common_cause_names=self._common_causes,
+                    observed_node_names=self._data.columns.tolist()
+                )
             elif instruments is not None:
                 self._graph = CausalGraph(
-                        self._treatment,
-                        self._outcome,
-                        instrument_names=self._instruments,
-                        observed_node_names = self._data.columns.tolist())
+                    self._treatment,
+                    self._outcome,
+                    instrument_names=self._instruments,
+                    observed_node_names=self._data.columns.tolist()
+                )
             else:
-                cli.query_yes_no("WARN: Are you sure that there are no common causes of treatment and outcome?",
-                        default=None)
+                cli.query_yes_no(
+                    "WARN: Are you sure that there are no common causes of treatment and outcome?",
+                    default=None
+                )
 
         else:
             self._graph = CausalGraph(
-                        self._treatment,
-                        self._outcome,
-                        graph,
-                        observed_node_names = self._data.columns.tolist())
+                self._treatment,
+                self._outcome,
+                graph,
+                observed_node_names=self._data.columns.tolist()
+            )
             self._common_causes = self._graph.get_common_causes(self._treatment, self._outcome)
             self._instruments = self._graph.get_instruments(self._treatment,
-                    self._outcome)
-
+                                                            self._outcome)
 
         self._other_variables = kwargs
         self.summary()
-        return
 
     def identify_effect(self):
         """Identify the causal effect to be estimated, using properties of the causal graph.
@@ -104,14 +110,13 @@ class CausalModel(object):
         :returns: a probability expression for the causal effect if identified, else NULL
 
         """
-        self.identifier=CausalIdentifier(self._graph, self._estimand_type)
+        self.identifier = CausalIdentifier(self._graph, self._estimand_type)
         identified_estimand = self.identifier.identify_effect()
 
         return identified_estimand
 
     def estimate_effect(self, identified_estimand, method_name=None,
-            test_significance=None,
-            method_params= None):
+                        test_significance=None, method_params=None):
         """Estimate the identified causal effect.
 
         If method_name is provided, uses the provided method. Else, finds a
@@ -136,19 +141,21 @@ class CausalModel(object):
 
         # Check if estimator's target estimand is identified
         if identified_estimand.estimands[identifier_name] is None:
-            self.logger.warn("No valid identified estimand for using instrumental variables method")
+            self.logger.warning("No valid identified estimand for using instrumental variables method")
             estimate = CausalEstimate(None, None, None)
         else:
-            causal_estimator  = causal_estimator_class(
-                    self._data,
-                    identified_estimand,
-                    self._treatment, self._outcome,
-                    test_significance = test_significance,
-                    params=method_params)
+            causal_estimator = causal_estimator_class(
+                self._data,
+                identified_estimand,
+                self._treatment, self._outcome,
+                test_significance=test_significance,
+                params=method_params
+            )
             estimate = causal_estimator.estimate_effect()
             estimate.add_params(
-                    estimand_type = identified_estimand.estimand_type,
-                    estimator_class = causal_estimator_class)
+                estimand_type=identified_estimand.estimand_type,
+                estimator_class=causal_estimator_class
+            )
         return estimate
 
     def refute_estimate(self, estimand, estimate, method_name=None, **kwargs):
@@ -167,13 +174,13 @@ class CausalModel(object):
             refuter_class = causal_refuters.get_class_object(method_name)
 
         refuter = refuter_class(
-                self._data,
-                identified_estimand=estimand,
-                estimate = estimate,
-                **kwargs)
-        res=refuter.refute_estimate()
+            self._data,
+            identified_estimand=estimand,
+            estimate=estimate,
+            **kwargs
+        )
+        res = refuter.refute_estimate()
         return res
-
 
     def view_model(self, layout="dot"):
         """View the causal DAG.
@@ -183,7 +190,6 @@ class CausalModel(object):
         """
         self._graph.view_graph(layout)
 
-
     def summary(self):
         """Print a text summary of the model.
 
@@ -191,6 +197,3 @@ class CausalModel(object):
 
         """
         print("Model to find the causal effect of treatment {0} on outcome {1}".format(self._treatment, self._outcome))
-
-
-

--- a/dowhy/plotter.py
+++ b/dowhy/plotter.py
@@ -5,47 +5,45 @@ SMALL_SIZE = 8
 MEDIUM_SIZE = 26
 BIGGER_SIZE = 30
 plt.rc('font', size=SMALL_SIZE)          # controls default text sizes
-plt.rc('axes', titlesize=BIGGER_SIZE)     # fontsize of the axes title
+plt.rc('axes', titlesize=BIGGER_SIZE)    # fontsize of the axes title
 plt.rc('axes', labelsize=MEDIUM_SIZE)    # fontsize of the x and y labels
-plt.rc('xtick', labelsize=MEDIUM_SIZE)    # fontsize of the tick labels
-plt.rc('ytick', labelsize=MEDIUM_SIZE)    # fontsize of the tick labels
-plt.rc('legend', fontsize=MEDIUM_SIZE)    # legend fontsize
+plt.rc('xtick', labelsize=MEDIUM_SIZE)   # fontsize of the tick labels
+plt.rc('ytick', labelsize=MEDIUM_SIZE)   # fontsize of the tick labels
+plt.rc('legend', fontsize=MEDIUM_SIZE)   # legend fontsize
 plt.rc('figure', titlesize=BIGGER_SIZE)  # fontsize of the figure title
-
 
 
 def plot_treatment_outcome(treatment, outcome, time_var):
     fig, ax = plt.subplots()
-    ax.plot(time_var,treatment,'o')
-    ax.plot(time_var,outcome, 'r^')
+    ax.plot(time_var, treatment, 'o')
+    ax.plot(time_var, outcome, 'r^')
 
-    plt.legend(loc="upper left", bbox_to_anchor=(0.4,1))
+    plt.legend(loc="upper left", bbox_to_anchor=(0.4, 1))
     plt.xlabel("Time")
-    #plt.show()plt.xlabel("Time"
     fig.set_size_inches(8, 6)
-    fig.savefig("poster_obs_data"+datetime.now().strftime("%H-%M-%s")+".png", bbox_inches="tight")
+    fig.savefig("poster_obs_data" + datetime.now().strftime("%H-%M-%s") + ".png",
+                bbox_inches="tight")
+
 
 def plot_causal_effect(estimate, treatment, outcome):
     fig, ax = plt.subplots()
     x_min = 0
     x_max = max(treatment)
-    y_min= estimate.params["intercept"]
-    y_max = y_min + estimate.value*(x_max-x_min)
-    ax.scatter(treatment, outcome,
-            c="gray", marker="o", label="Observed data")
-    ax.plot([x_min, x_max], [y_min, y_max], c="black", ls="solid", lw=4, label="Causal variation")
-    ax.set_ylim(0, max(outcome ))
+    y_min = estimate.params["intercept"]
+    y_max = y_min + estimate.value * (x_max - x_min)
+    ax.scatter(treatment, outcome, c="gray", marker="o", label="Observed data")
+    ax.plot([x_min, x_max], [y_min, y_max], c="black", ls="solid", lw=4,
+            label="Causal variation")
+    ax.set_ylim(0, max(outcome))
     ax.set_xlim(0, x_max)
 
     bbox_props = dict(boxstyle="round", fc="w", ec="0.5", alpha=0.9)
-    ax.text(10.8, 1, r"DoWhy estimate $\rho$ (slope) = " +str(round(estimate.value, 2)), ha="right", va="bottom", size=20, bbox=bbox_props)
+    ax.text(10.8, 1, r"DoWhy estimate $\rho$ (slope) = " + str(round(estimate.value, 2)),
+            ha="right", va="bottom", size=20, bbox=bbox_props)
     ax.legend(loc="upper left")
     plt.xlabel("Treatment")
     plt.ylabel("Outcome")
 
-    #plt.show()
     fig.set_size_inches(8, 6)
-    fig.savefig("poster_effect"+datetime.now().strftime("%H-%M-%s")+".png", bbox_inches='tight')
-
-
-
+    fig.savefig("poster_effect" + datetime.now().strftime("%H-%M-%s") + ".png",
+                bbox_inches='tight')

--- a/dowhy/utils/cli_helpers.py
+++ b/dowhy/utils/cli_helpers.py
@@ -2,23 +2,23 @@ def query_yes_no(question, default=True):
     """Ask a yes/no question via standard input and return the answer.
 
     Source: https://stackoverflow.com/questions/3041986/apt-command-line-interface-like-yes-no-input
-    
+
     If invalid input is given, the user will be asked until they actually give valid input.
-    Args:         
+    Args:
         question(str):  A question that is presented to the user.
-        default(bool|None): The default value when enter is pressed with no value. 
+        default(bool|None): The default value when enter is pressed with no value.
         When None, there is no default value and the query will loop.
     Returns:
-        A bool indicating whether user has entered yes or no.      
+        A bool indicating whether user has entered yes or no.
     Side Effects:
-        Blocks program execution until valid input(y/n) is given.     
-    """ 
+        Blocks program execution until valid input(y/n) is given.
+    """
     yes_list = ["yes", "y"]
     no_list = ["no", "n"]
-    default_dict = {  # default => prompt default string         
-            None: "[y/n]",         
-            True: "[Y/n]",      
-            False: "[y/N]"
+    default_dict = {  # default => prompt default string
+        None: "[y/n]",
+        True: "[Y/n]",
+        False: "[y/N]"
     }
     default_str = default_dict[default]
     prompt_str = "%s %s " % (question, default_str)

--- a/setup.py
+++ b/setup.py
@@ -16,17 +16,17 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='dowhy',  
+    name='dowhy',
 
-    version='0.1.0',  
+    version='0.1.0',
 
     description='A Python library for causal inference',  # Required
 
-    long_description=long_description,  
+    long_description=long_description,
 
     url='https://causalinference.gitlab.io/dowhy',  # Optional
 
-    author='Amit Sharma, Emre Kiciman',  
+    author='Amit Sharma, Emre Kiciman',
 
 
     classifiers=[  # Optional
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests']),
     python_requires='>=3.0',
 
-    install_requires=['numpy', 'scikit-learn', 'matplotlib', 'scipy', 
-            'pandas', 'pygraphviz', 'networkx', 'sympy'],  
+    install_requires=['numpy', 'scikit-learn', 'matplotlib', 'scipy',
+                      'pandas', 'pygraphviz', 'networkx', 'sympy'],
 
 )

--- a/tests/causal_estimators/test_linear_regression_estimator.py
+++ b/tests/causal_estimators/test_linear_regression_estimator.py
@@ -1,49 +1,51 @@
-import unittest
-import pytest
 import numpy as np
 import pandas as pd
-#from tests.definitions import  DATA_PATH
+import pytest
+
 from dowhy.causal_estimators.linear_regression_estimator import LinearRegressionEstimator
 from dowhy.causal_identifier import IdentifiedEstimand
 
+
 @pytest.fixture(params=[(10, 5, 100000), (10, 5, 100000)])
-def linear_dataset(request):#beta, num_common_causes, num_samples):
+def linear_dataset(request):  # beta, num_common_causes, num_samples):
     beta = request.param[0]
     num_common_causes = request.param[1]
     num_samples = request.param[2]
-    range_c1 = beta*0.5
-    range_c2 = beta*0.5
+    range_c1 = beta * 0.5
+    range_c2 = beta * 0.5
     means = np.random.uniform(-1, 1, num_common_causes)
     cov_mat = np.diag(np.ones(num_common_causes))
     X = np.random.multivariate_normal(means, cov_mat, num_samples)
     c1 = np.random.uniform(0, range_c1, num_common_causes)
     c2 = np.random.uniform(0, range_c2, num_common_causes)
 
-    t = X @ c1 #+ np.random.normal(0, 0.01)
-    y = X @ c2 + beta*t #+ np.random.normal(0,0.01)
+    t = X @ c1  # + np.random.normal(0, 0.01)
+    y = X @ c2 + beta * t  # + np.random.normal(0,0.01)
     print(c1)
     print(c2)
-    ty = np.column_stack((t,y))
+    ty = np.column_stack((t, y))
     data = np.column_stack((X, ty))
 
     treatment = "t"
     outcome = "y"
-    common_causes = [("X"+str(i)) for i in range(0, num_common_causes)]
+    common_causes = [("X" + str(i)) for i in range(0, num_common_causes)]
     ate = beta
     instruments = None
     other_variables = None
     col_names = common_causes + [treatment, outcome]
     data = pd.DataFrame(data,
-            columns = col_names)
+                        columns=col_names)
     ret_dict = {
-            "data": data,
-            "treatment": treatment,
-            "outcome": outcome,
-            "common_causes": common_causes,
-            "ate": beta}
-    return(ret_dict)
+        "data": data,
+        "treatment": treatment,
+        "outcome": outcome,
+        "common_causes": common_causes,
+        "ate": beta
+    }
+    return ret_dict
 
-#@pytest.mark.usefixtures("simulate_linear_dataset")
+
+# @pytest.mark.usefixtures("simulate_linear_dataset")
 class TestLinearRegressionEstimator(object):
 
     @pytest.mark.parametrize("error_tolerance", [0.01, 0.05])
@@ -51,19 +53,21 @@ class TestLinearRegressionEstimator(object):
         data = linear_dataset["data"]
         true_ate = linear_dataset["ate"]
         target_estimand = IdentifiedEstimand(
-                treatment_variable = linear_dataset["treatment"],
-                outcome_variable = linear_dataset["outcome"],
-                backdoor_variables = linear_dataset["common_causes"])
+            treatment_variable=linear_dataset["treatment"],
+            outcome_variable=linear_dataset["outcome"],
+            backdoor_variables=linear_dataset["common_causes"]
+        )
         estimator_ate = LinearRegressionEstimator(
-                 data,
-                 identified_estimand = target_estimand,
-                 treatment=linear_dataset["treatment"],
-                 outcome=linear_dataset["outcome"])
+            data,
+            identified_estimand=target_estimand,
+            treatment=linear_dataset["treatment"],
+            outcome=linear_dataset["outcome"]
+        )
 
         est_ate = estimator_ate.estimate_effect()
         error = est_ate.value - true_ate
         print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
-            error, error_tolerance*100, est_ate.value, true_ate))
-        res = True if (error < true_ate*error_tolerance) else False
+            error, error_tolerance * 100, est_ate.value, true_ate)
+        )
+        res = True if (error < true_ate * error_tolerance) else False
         assert res
-

--- a/tests/data_transformers/test_pca_reducer.py
+++ b/tests/data_transformers/test_pca_reducer.py
@@ -1,21 +1,22 @@
-from matplotlib import pyplot as plt
-import matplotlib
+import numpy as np
 import pytest
-import  numpy as np
-import pandas as pd
+from matplotlib import pyplot as plt
 
 from dowhy.data_transformers.pca_reducer import PCAReducer
+
 
 @pytest.fixture()
 def feature_matrix():
     num_features = 2
     num_samples = 10000
     means = np.random.uniform(-1, 1, num_features)
-    #cov_mat = np.diag(np.ones(num_features))
+    # cov_mat = np.diag(np.ones(num_features))
     cov_mat = np.ones((num_features, num_features))
-    cov_mat[0,1]=0.5; cov_mat[1,0]=0.5
+    cov_mat[0, 1] = 0.5
+    cov_mat[1, 0] = 0.5
     X = np.random.multivariate_normal(means, cov_mat, num_samples)
     return X
+
 
 class TestPCAReducer:
     def test_reduce(self, feature_matrix):
@@ -23,14 +24,19 @@ class TestPCAReducer:
         X_pca = reducer.reduce()
         print(feature_matrix)
         print(X_pca)
-        plt.scatter(feature_matrix[:,0], feature_matrix[:,1], c="g")
+        plt.scatter(feature_matrix[:, 0], feature_matrix[:, 1], c="g")
         plt.xlabel("Dim 0")
         plt.ylabel("Dim 1")
-        plt.scatter(X_pca[:,0], X_pca[:,1], alpha=0.5)
+        plt.scatter(X_pca[:, 0], X_pca[:, 1], alpha=0.5)
         plt.show()
 
-        dist_origin = np.square(feature_matrix[:,0]-np.mean(feature_matrix[:,0])) +np.square(feature_matrix[:,1] - np.mean(feature_matrix[:,1]))
-        dist_origin_pca = np.square(X_pca[:,0]-np.mean(X_pca[:,0]))+np.square(X_pca[:,1]-np.mean(X_pca[:,1]))
-        print ((dist_origin_pca-dist_origin)/dist_origin)
-        assert all(abs(dist_origin_pca-dist_origin))<0.001
-
+        dist_origin = (
+            np.square(feature_matrix[:, 0] - np.mean(feature_matrix[:, 0])) +
+            np.square(feature_matrix[:, 1] - np.mean(feature_matrix[:, 1]))
+        )
+        dist_origin_pca = (
+            np.square(X_pca[:, 0] - np.mean(X_pca[:, 0])) +
+            np.square(X_pca[:, 1] - np.mean(X_pca[:, 1]))
+        )
+        print((dist_origin_pca - dist_origin) / dist_origin)
+        assert all(abs(dist_origin_pca - dist_origin)) < 0.001

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -1,5 +1,4 @@
 import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-DATA_PATH=os.path.join(ROOT_DIR, os.pardir, "datasets")
-
+DATA_PATH = os.path.join(ROOT_DIR, os.pardir, "datasets")

--- a/tests/test_causal_estimator.py
+++ b/tests/test_causal_estimator.py
@@ -1,25 +1,22 @@
 import unittest
-import os
-import pandas as pd
-import numpy as np
-from tests.definitions import DATA_PATH
+
 
 class TestCausalEstimator(unittest.TestCase):
     def setUp(self):
-        #self.df = pd.read_csv(os.path.join(DATA_PATH,'dgp_1/acic_1_1_data.csv'))
-        #self.ate = np.mean(self.df['y1'] - self.df['y0'])
-        #treated = self.df[self.df['z']==1]
-        #self.att = np.mean(treated['y1'] - treated['y0'])
-        self.df=None
-        self.ate=1
+        # self.df = pd.read_csv(os.path.join(DATA_PATH,'dgp_1/acic_1_1_data.csv'))
+        # self.ate = np.mean(self.df['y1'] - self.df['y0'])
+        # treated = self.df[self.df['z']==1]
+        # self.att = np.mean(treated['y1'] - treated['y0'])
+        self.df = None
+        self.ate = 1
 
-    #def test_average_treatment_effect(self):
+    # def test_average_treatment_effect(self):
     #     est_ate = 1
     #     bias = est_ate - self.ate
     #     print(bias)
     #     self.assertAlmostEqual(self.ate, est_ate)
 
-    #def test_average_treatment_effect_on_treated(self):
+    # def test_average_treatment_effect_on_treated(self):
     #    est_att = 1
     #    self.att=1
     #    bias = est_att - self.att
@@ -27,5 +24,5 @@ class TestCausalEstimator(unittest.TestCase):
     #    self.assertAlmostEqual(self.att, est_att)
 
 
-if __name__=="__main__":
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Clean up the code a bit (mostly standard PyCharm fixes). Changes are generally for style, little functional changes:

- Remove unused imports and reorder them.
- Fix indentation.
- Remove trailing whitespaces.
- Fix whitespace around operators.
- Fix some of the line lengths.
- Fix some of the commented-out code.

This PR reduces [flake8](http://flake8.pycqa.org/en/latest/)'s total number of warnings & errors from 578 to 130.