### PR TITLE
Missing sklearn dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 networkx
 matplotlib
 sympy
+scikit-learn


### PR DESCRIPTION
When running `python setup.py test` on a fresh 3.6 virtualenv:

```
[...]
======================================================================
ERROR: linear_regression_estimator (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: linear_regression_estimator
Traceback (most recent call last):
  File "/usr/lib64/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/tmp/dowhy/dowhy/causal_estimators/linear_regression_estimator.py", line 2, in <module>
    from sklearn import linear_model
ModuleNotFoundError: No module named 'sklearn'


----------------------------------------------------------------------
Ran 5 tests in 0.001s

FAILED (errors=5)
Test failed: <unittest.runner.TextTestResult run=5 errors=5 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=5 errors=5 failures=0>
```

Although it was present in the README, the `scikit-learn` package was missing from the `requirements.txt` file.