### PR TITLE
Add test coverage

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -51,7 +51,7 @@ class CausalEstimator:
         est = self._estimate_effect()
         # self._estimate = est
 
-        if self._significance_test is not None:
+        if self._significance_test:
             signif_dict = self.test_significance(est)
             est.add_significance_test_results(signif_dict)
         return est

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -8,11 +8,12 @@ import dowhy.utils.cli_helpers as cli
 
 class CausalIdentifier:
 
-    def __init__(self, graph, estimand_type):
+    def __init__(self, graph, estimand_type, proceed_when_unidentifiable=False):
         self._graph = graph
         self.estimand_type = estimand_type
         self.treatment_name = graph.treatment_name
         self.outcome_name = graph.outcome_name
+        self._proceed_when_unidentifiable = proceed_when_unidentifiable
         self.logger = logging.getLogger(__name__)
 
     def identify_effect(self):
@@ -21,7 +22,7 @@ class CausalIdentifier:
         causes_of_outcome = self._graph.get_ancestors(self.outcome_name)
         common_causes = set(causes_of_treatment).intersection(causes_of_outcome)
         self.logger.info("Common causes of treatment and outcome:" + str(common_causes))
-        if self._graph.all_observed(common_causes):
+        if self._graph.all_observed(common_causes) or self._proceed_when_unidentifiable:
             print("All common causes are observed. Causal effect can be identified.")
         else:
             print("There are unobserved common causes. Causal effect cannot be identified.")

--- a/dowhy/do_why.py
+++ b/dowhy/do_why.py
@@ -25,6 +25,7 @@ class CausalModel:
 
     def __init__(self, data, treatment, outcome, graph=None,
                  common_causes=None, instruments=None, estimand_type="ate",
+                 proceed_when_unidentifiable=False,
                  **kwargs):
         """Initialize data and create a causal graph instance.
 
@@ -50,6 +51,7 @@ class CausalModel:
         self._treatment = treatment
         self._outcome = outcome
         self._estimand_type = estimand_type
+        self._proceed_when_unidentifiable = proceed_when_unidentifiable
         if 'logging_level' in kwargs:
             logging.basicConfig(level=kwargs['logging_level'])
         else:
@@ -110,7 +112,9 @@ class CausalModel:
         :returns: a probability expression for the causal effect if identified, else NULL
 
         """
-        self.identifier = CausalIdentifier(self._graph, self._estimand_type)
+        self.identifier = CausalIdentifier(self._graph,
+                                           self._estimand_type,
+                                           proceed_when_unidentifiable=self._proceed_when_unidentifiable)
         identified_estimand = self.identifier.identify_effect()
 
         return identified_estimand

--- a/tests/causal_estimators/base.py
+++ b/tests/causal_estimators/base.py
@@ -1,0 +1,44 @@
+import dowhy.datasets
+
+from dowhy.do_why import CausalModel
+
+
+class TestEstimator(object):
+    def __init__(self, error_tolerance, Estimator):
+        print(error_tolerance)
+        self._error_tolerance = error_tolerance
+        self._Estimator = Estimator
+        print(self._error_tolerance)
+
+    def average_treatment_effect_test(self):
+        data = dowhy.datasets.linear_dataset(beta=10,
+                                             num_common_causes=1,
+                                             num_instruments=1,
+                                             num_samples=10000,
+                                             treatment_is_binary=True)
+
+        model = CausalModel(
+            data=data['df'],
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            graph=data["gml_graph"],
+            proceed_when_unidentifiable=True,
+            test_significance=None
+        )
+        target_estimand = model.identify_effect()
+        estimator_ate = self._Estimator(
+            data['df'],
+            identified_estimand=target_estimand,
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            test_significance=None
+        )
+        true_ate = data["ate"]
+        ate_estimate = estimator_ate.estimate_effect()
+        error = ate_estimate.value - true_ate
+        print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
+            error, self._error_tolerance * 100, ate_estimate.value, true_ate)
+        )
+        res = True if (error < true_ate * self._error_tolerance) else False
+        assert res
+

--- a/tests/causal_estimators/test_instrumental_variable_estimator.py
+++ b/tests/causal_estimators/test_instrumental_variable_estimator.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
+from dowhy.causal_identifier import IdentifiedEstimand
+
+
+class TestInstrumentalVariableEstimator(object):
+
+    @pytest.mark.parametrize("error_tolerance", [0.01, 0.05])
+    def test_average_treatment_effect(self, linear_dataset, error_tolerance):
+        data = linear_dataset["data"]
+        true_ate = linear_dataset["ate"]
+        target_estimand = IdentifiedEstimand(
+            treatment_variable=linear_dataset["treatment"],
+            outcome_variable=linear_dataset["outcome"],
+            backdoor_variables=linear_dataset["common_causes"]
+        )
+        estimator_ate = LinearRegressionEstimator(
+            data,
+            identified_estimand=target_estimand,
+            treatment=linear_dataset["treatment"],
+            outcome=linear_dataset["outcome"]
+        )
+
+        est_ate = estimator_ate.estimate_effect()
+        error = est_ate.value - true_ate
+        print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
+            error, error_tolerance * 100, est_ate.value, true_ate)
+        )
+        res = True if (error < true_ate * error_tolerance) else False
+        assert res

--- a/tests/causal_estimators/test_instrumental_variable_estimator.py
+++ b/tests/causal_estimators/test_instrumental_variable_estimator.py
@@ -1,33 +1,41 @@
-import numpy as np
-import pandas as pd
 import pytest
+import dowhy.datasets
 
 from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
-from dowhy.causal_identifier import IdentifiedEstimand
+from dowhy.do_why import CausalModel
 
 
 class TestInstrumentalVariableEstimator(object):
 
-    @pytest.mark.parametrize("error_tolerance", [0.01, 0.05])
-    def test_average_treatment_effect(self, linear_dataset, error_tolerance):
-        data = linear_dataset["data"]
-        true_ate = linear_dataset["ate"]
-        target_estimand = IdentifiedEstimand(
-            treatment_variable=linear_dataset["treatment"],
-            outcome_variable=linear_dataset["outcome"],
-            backdoor_variables=linear_dataset["common_causes"]
+    @pytest.mark.parametrize("error_tolerance", [0.05, 0.1])
+    def test_average_treatment_effect(self, error_tolerance):
+        data = dowhy.datasets.linear_dataset(beta=10,
+                                             num_common_causes=1,
+                                             num_instruments=1,
+                                             num_samples=5000,
+                                             treatment_is_binary=True)
+
+        model = CausalModel(
+            data=data['df'],
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            graph=data["gml_graph"],
+            proceed_when_unidentifiable=True
         )
-        estimator_ate = LinearRegressionEstimator(
-            data,
+        true_ate = data["ate"]
+        target_estimand = model.identify_effect()
+        estimator_ate = InstrumentalVariableEstimator(
+            data['df'],
             identified_estimand=target_estimand,
-            treatment=linear_dataset["treatment"],
-            outcome=linear_dataset["outcome"]
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            test_significance=False
         )
 
-        est_ate = estimator_ate.estimate_effect()
-        error = est_ate.value - true_ate
+        ate_estimate = estimator_ate.estimate_effect()
+        error = ate_estimate.value - true_ate
         print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
-            error, error_tolerance * 100, est_ate.value, true_ate)
+            error, error_tolerance * 100, ate_estimate.value, true_ate)
         )
         res = True if (error < true_ate * error_tolerance) else False
         assert res

--- a/tests/causal_estimators/test_linear_regression_estimator.py
+++ b/tests/causal_estimators/test_linear_regression_estimator.py
@@ -1,37 +1,12 @@
 import pytest
 
 from dowhy.causal_estimators.linear_regression_estimator import LinearRegressionEstimator
-from dowhy.causal_identifier import IdentifiedEstimand
-from dowhy.datasets import linear_dataset
+from .base import TestEstimator
 
 
-class TestLinearRegressionEstimator(object):
-
-    @pytest.mark.parametrize("error_tolerance", [0.01, 0.05])
-    def test_average_treatment_effect(self, error_tolerance):
-        data = linear_dataset(beta=10,
-                              num_common_causes=1,
-                              num_instruments=1,
-                              num_samples=5000,
-                              treatment_is_binary=True)
-        true_ate = data["ate"]
-        target_estimand = IdentifiedEstimand(
-            treatment_variable=data["treatment_name"],
-            outcome_variable=data["outcome_name"],
-            backdoor_variables=data["common_causes_names"]
-        )
-        estimator_ate = LinearRegressionEstimator(
-            data['df'],
-            identified_estimand=target_estimand,
-            treatment=data["treatment_name"],
-            outcome=data["outcome_name"],
-            test_significance=False
-        )
-
-        est_ate = estimator_ate.estimate_effect()
-        error = est_ate.value - true_ate
-        print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
-            error, error_tolerance * 100, est_ate.value, true_ate)
-        )
-        res = True if (error < true_ate * error_tolerance) else False
-        assert res
+class TestPropensityScoreMatchingEstimator(object):
+    @pytest.mark.parametrize(["error_tolerance", "Estimator"],
+                             [(0.05, LinearRegressionEstimator),])
+    def test_average_treatment_effect(self, error_tolerance, Estimator):
+        estimator_tester = TestEstimator(error_tolerance, Estimator)
+        estimator_tester.average_treatment_effect_test()

--- a/tests/causal_estimators/test_linear_regression_estimator.py
+++ b/tests/causal_estimators/test_linear_regression_estimator.py
@@ -1,67 +1,31 @@
-import numpy as np
-import pandas as pd
 import pytest
 
 from dowhy.causal_estimators.linear_regression_estimator import LinearRegressionEstimator
 from dowhy.causal_identifier import IdentifiedEstimand
+from dowhy.datasets import linear_dataset
 
 
-@pytest.fixture(params=[(10, 5, 100000), (10, 5, 100000)])
-def linear_dataset(request):  # beta, num_common_causes, num_samples):
-    beta = request.param[0]
-    num_common_causes = request.param[1]
-    num_samples = request.param[2]
-    range_c1 = beta * 0.5
-    range_c2 = beta * 0.5
-    means = np.random.uniform(-1, 1, num_common_causes)
-    cov_mat = np.diag(np.ones(num_common_causes))
-    X = np.random.multivariate_normal(means, cov_mat, num_samples)
-    c1 = np.random.uniform(0, range_c1, num_common_causes)
-    c2 = np.random.uniform(0, range_c2, num_common_causes)
-
-    t = X @ c1  # + np.random.normal(0, 0.01)
-    y = X @ c2 + beta * t  # + np.random.normal(0,0.01)
-    print(c1)
-    print(c2)
-    ty = np.column_stack((t, y))
-    data = np.column_stack((X, ty))
-
-    treatment = "t"
-    outcome = "y"
-    common_causes = [("X" + str(i)) for i in range(0, num_common_causes)]
-    ate = beta
-    instruments = None
-    other_variables = None
-    col_names = common_causes + [treatment, outcome]
-    data = pd.DataFrame(data,
-                        columns=col_names)
-    ret_dict = {
-        "data": data,
-        "treatment": treatment,
-        "outcome": outcome,
-        "common_causes": common_causes,
-        "ate": beta
-    }
-    return ret_dict
-
-
-# @pytest.mark.usefixtures("simulate_linear_dataset")
 class TestLinearRegressionEstimator(object):
 
     @pytest.mark.parametrize("error_tolerance", [0.01, 0.05])
-    def test_average_treatment_effect(self, linear_dataset, error_tolerance):
-        data = linear_dataset["data"]
-        true_ate = linear_dataset["ate"]
+    def test_average_treatment_effect(self, error_tolerance):
+        data = linear_dataset(beta=10,
+                              num_common_causes=1,
+                              num_instruments=1,
+                              num_samples=5000,
+                              treatment_is_binary=True)
+        true_ate = data["ate"]
         target_estimand = IdentifiedEstimand(
-            treatment_variable=linear_dataset["treatment"],
-            outcome_variable=linear_dataset["outcome"],
-            backdoor_variables=linear_dataset["common_causes"]
+            treatment_variable=data["treatment_name"],
+            outcome_variable=data["outcome_name"],
+            backdoor_variables=data["common_causes_names"]
         )
         estimator_ate = LinearRegressionEstimator(
-            data,
+            data['df'],
             identified_estimand=target_estimand,
-            treatment=linear_dataset["treatment"],
-            outcome=linear_dataset["outcome"]
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            test_significance=False
         )
 
         est_ate = estimator_ate.estimate_effect()

--- a/tests/causal_estimators/test_propensity_score_matching_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_matching_estimator.py
@@ -1,13 +1,12 @@
+from dowhy.causal_estimators.propensity_score_matching_estimator import PropensityScoreMatchingEstimator
 import pytest
 
-from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
 from .base import TestEstimator
 
 
 class TestPropensityScoreMatchingEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator"],
-                             [(0.05, InstrumentalVariableEstimator),
-                              (0.1, InstrumentalVariableEstimator)])
+                             [(0.05, PropensityScoreMatchingEstimator),])
     def test_average_treatment_effect(self, error_tolerance, Estimator):
         estimator_tester = TestEstimator(error_tolerance, Estimator)
         estimator_tester.average_treatment_effect_test()

--- a/tests/causal_estimators/test_propensity_score_stratification_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_stratification_estimator.py
@@ -1,13 +1,13 @@
 import pytest
 
-from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
+from dowhy.causal_estimators.propensity_score_stratification_estimator import PropensityScoreStratificationEstimator
 from .base import TestEstimator
 
 
 class TestPropensityScoreMatchingEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator"],
-                             [(0.05, InstrumentalVariableEstimator),
-                              (0.1, InstrumentalVariableEstimator)])
+                             [(0.01, PropensityScoreStratificationEstimator),
+                              (0.05, PropensityScoreStratificationEstimator)])
     def test_average_treatment_effect(self, error_tolerance, Estimator):
         estimator_tester = TestEstimator(error_tolerance, Estimator)
         estimator_tester.average_treatment_effect_test()

--- a/tests/causal_estimators/test_propensity_score_weighting_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_weighting_estimator.py
@@ -1,13 +1,13 @@
 import pytest
 
-from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
+from dowhy.causal_estimators.propensity_score_weighting_estimator import PropensityScoreWeightingEstimator
 from .base import TestEstimator
 
 
 class TestPropensityScoreMatchingEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator"],
-                             [(0.05, InstrumentalVariableEstimator),
-                              (0.1, InstrumentalVariableEstimator)])
+                             [(0.01, PropensityScoreWeightingEstimator),
+                              (0.05, PropensityScoreWeightingEstimator)])
     def test_average_treatment_effect(self, error_tolerance, Estimator):
         estimator_tester = TestEstimator(error_tolerance, Estimator)
         estimator_tester.average_treatment_effect_test()


### PR DESCRIPTION
* Updated the `CausalModel` to allow suppression of CLI prompts when an effect is determined to be unidentified using a kwarg. (Allows tests to run when specifying the backdoor set explicitly, and inconsistently with the graph).
* Added test coverage for IVs
* Updated the linear model test coverage to use the `linear_dataset` helper, instead of generating one from scratch.
* All tests pass