### PR TITLE
Exposes num_simulations parameter to allow user to limit significance test simulations

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -46,20 +46,14 @@ class CausalEstimator:
         :returns: point estimate of causal effect
 
         """
-        print(f"NOTE: Entered **estimate_effect** of **CausalEstimator** in file **causal_estimator.py**")
         self._treatment = self._data[self._treatment_name]
         self._outcome = self._data[self._outcome_name]
-        print(f"NOTE: About to call **_estimate_effect()** in **CausalEstimator** in file **causal_estimator.py**")
         est = self._estimate_effect()
-        print(f"NOTE: Received **estimate** object from **_estimate_effect** (in **propensity_score_matching_estimator**) in **CausalEstimator** in file **causal_estimator.py** with value {est.value}.")
         # self._estimate = est
 
         if self._significance_test:
-            print(f"NOTE: About to call **test_significance()** on the received estimate **est** in file **causal_estimator.py** with {num_simulations} simulations.")
             signif_dict = self.test_significance(est, num_simulations=num_simulations)
-            print(f"NOTE: Received **signif_dif** from  **test_significance()** on the estimate **est** in file **causal_estimator.py**")
             est.add_significance_test_results(signif_dict)
-        print(f"NOTE: About to return **estimate** object to **do_why.py** variable **estimate**.")
         return est
 
     def _do(self, x):

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -90,7 +90,6 @@ class CausalEstimator:
         null_estimates = np.zeros(self.num_simulations)
         for i in range(self.num_simulations):
             self._outcome = np.random.permutation(self._outcome)
-            self._significance_test=False
             est = self._estimate_effect()
             null_estimates[i] = est.value
 

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -88,18 +88,15 @@ class CausalEstimator:
         if not hasattr(self,'num_simulations'):
             self.num_simulations = num_simulations
         null_estimates = np.zeros(self.num_simulations)
-        print(f"NOTE: About to create **null_estimates** array in file **causal_estimator.py**")
         for i in range(self.num_simulations):
             self._outcome = np.random.permutation(self._outcome)
             self._significance_test=False
-            print(f"NOTE: About to call **_estimate_effect()** in the **test_significance** method in file **causal_estimator.py** with _significance_test={self._significance_test}")
             est = self._estimate_effect()
             null_estimates[i] = est.value
 
         sorted_null_estimates = np.sort(null_estimates)
         self.logger.debug("Null estimates: {0}".format(sorted_null_estimates))
         median_estimate = sorted_null_estimates[int(self.num_simulations / 2)]
-        print(f"NOTE: About to create **null_estimates** array in file **causal_estimator.py**")
         # Doing a two-sided test
         if estimate.value > median_estimate:
             # Being conservative with the p-value reported

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -37,7 +37,7 @@ class CausalEstimator:
 
         self.logger = logging.getLogger(__name__)
 
-    def estimate_effect(self):
+    def estimate_effect(self, num_simulations):
         """TODO.
 
         More description.
@@ -46,15 +46,20 @@ class CausalEstimator:
         :returns: point estimate of causal effect
 
         """
+        print(f"NOTE: Entered **estimate_effect** of **CausalEstimator** in file **causal_estimator.py**")
         self._treatment = self._data[self._treatment_name]
         self._outcome = self._data[self._outcome_name]
+        print(f"NOTE: About to call **_estimate_effect()** in **CausalEstimator** in file **causal_estimator.py**")
         est = self._estimate_effect()
+        print(f"NOTE: Received **estimate** object from **_estimate_effect** (in **propensity_score_matching_estimator**) in **CausalEstimator** in file **causal_estimator.py** with value {est.value}.")
         # self._estimate = est
 
-
         if self._significance_test:
-            signif_dict = self.test_significance(est)
+            print(f"NOTE: About to call **test_significance()** on the received estimate **est** in file **causal_estimator.py** with {num_simulations} simulations.")
+            signif_dict = self.test_significance(est, num_simulations=num_simulations)
+            print(f"NOTE: Received **signif_dif** from  **test_significance()** on the estimate **est** in file **causal_estimator.py**")
             est.add_significance_test_results(signif_dict)
+        print(f"NOTE: About to return **estimate** object to **do_why.py** variable **estimate**.")
         return est
 
     def _do(self, x):
@@ -89,14 +94,18 @@ class CausalEstimator:
         if not hasattr(self,'num_simulations'):
             self.num_simulations = num_simulations
         null_estimates = np.zeros(self.num_simulations)
+        print(f"NOTE: About to create **null_estimates** array in file **causal_estimator.py**")
         for i in range(self.num_simulations):
             self._outcome = np.random.permutation(self._outcome)
+            self._significance_test=False
+            print(f"NOTE: About to call **_estimate_effect()** in the **test_significance** method in file **causal_estimator.py** with _significance_test={self._significance_test}")
             est = self._estimate_effect()
             null_estimates[i] = est.value
 
         sorted_null_estimates = np.sort(null_estimates)
         self.logger.debug("Null estimates: {0}".format(sorted_null_estimates))
         median_estimate = sorted_null_estimates[int(self.num_simulations / 2)]
+        print(f"NOTE: About to create **null_estimates** array in file **causal_estimator.py**")
         # Doing a two-sided test
         if estimate.value > median_estimate:
             # Being conservative with the p-value reported

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -20,6 +20,7 @@ class PropensityScoreMatchingEstimator(CausalEstimator):
         self.logger.info(self.symbolic_estimator)
 
     def _estimate_effect(self):
+        print(f"NOTE: Entered **_estimate_effect** of **PropensityScoreMatchingEstimator** in file **propensity_score_matching_estimator.py**")
         propensity_score_model = linear_model.LinearRegression()
         propensity_score_model.fit(self._observed_common_causes, self._treatment)
         self._data['propensity_score'] = propensity_score_model.predict(self._observed_common_causes)
@@ -45,10 +46,12 @@ class PropensityScoreMatchingEstimator(CausalEstimator):
             ate += treated_outcome - control_outcome
 
         ate /= numtreatedunits
-
+        print(f"NOTE: ATE: {ate}")
+        print(f"NOTE: About to call **CausalEstimate** in **PropenseityScoreMatchingEstimator** in file **propensity_score_matching_estimator.py**")
         estimate = CausalEstimate(estimate=ate,
                                   target_estimand=self._target_estimand,
                                   realized_estimand_expr=self.symbolic_estimator)
+        print(f"NOTE: Created **CausalEstimate** object in **_estimate_effect** in **PropensityScoreMatchingEstimator** in file **propensity_score_matching_estimator.py** with value {estimate.value}.")
         return estimate
 
     def construct_symbolic_estimator(self, estimand):

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -20,7 +20,6 @@ class PropensityScoreMatchingEstimator(CausalEstimator):
         self.logger.info(self.symbolic_estimator)
 
     def _estimate_effect(self):
-        print(f"NOTE: Entered **_estimate_effect** of **PropensityScoreMatchingEstimator** in file **propensity_score_matching_estimator.py**")
         propensity_score_model = linear_model.LinearRegression()
         propensity_score_model.fit(self._observed_common_causes, self._treatment)
         self._data['propensity_score'] = propensity_score_model.predict(self._observed_common_causes)
@@ -46,12 +45,9 @@ class PropensityScoreMatchingEstimator(CausalEstimator):
             ate += treated_outcome - control_outcome
 
         ate /= numtreatedunits
-        print(f"NOTE: ATE: {ate}")
-        print(f"NOTE: About to call **CausalEstimate** in **PropenseityScoreMatchingEstimator** in file **propensity_score_matching_estimator.py**")
         estimate = CausalEstimate(estimate=ate,
                                   target_estimand=self._target_estimand,
                                   realized_estimand_expr=self.symbolic_estimator)
-        print(f"NOTE: Created **CausalEstimate** object in **_estimate_effect** in **PropensityScoreMatchingEstimator** in file **propensity_score_matching_estimator.py** with value {estimate.value}.")
         return estimate
 
     def construct_symbolic_estimator(self, estimand):

--- a/dowhy/do_why.py
+++ b/dowhy/do_why.py
@@ -120,7 +120,8 @@ class CausalModel:
         return identified_estimand
 
     def estimate_effect(self, identified_estimand, method_name=None,
-                        test_significance=None, method_params=None):
+                        test_significance=None, method_params=None,
+                        num_simulations=1000):
         """Estimate the identified causal effect.
 
         If method_name is provided, uses the provided method. Else, finds a
@@ -134,6 +135,7 @@ class CausalModel:
             and other method-dependent information
 
         """
+        print(f"NOTE: Entered **estimate_effect** of **CausalModel** in file **do_why.py**")
         if method_name is None:
             pass
         else:
@@ -148,6 +150,7 @@ class CausalModel:
             self.logger.warning("No valid identified estimand for using instrumental variables method")
             estimate = CausalEstimate(None, None, None)
         else:
+            print(f"NOTE: causal_estimator_class: {causal_estimator_class}.")
             causal_estimator = causal_estimator_class(
                 self._data,
                 identified_estimand,
@@ -155,11 +158,15 @@ class CausalModel:
                 test_significance=test_significance,
                 params=method_params
             )
-            estimate = causal_estimator.estimate_effect()
+            print(f"NOTE: causal_estimator: {causal_estimator}.")
+            print(f"NOTE: About to call **causal_estimator.estimate_effect()** in **CausalModel** in file **do_why.py** with {num_simulations} simulations.")
+            estimate = causal_estimator.estimate_effect(num_simulations)
+            print(f"NOTE: Received **estimate** object with value {estimate.value} from **CausalEstimator** in **causal_estimator.py**")
             estimate.add_params(
                 estimand_type=identified_estimand.estimand_type,
                 estimator_class=causal_estimator_class
             )
+            print(f"NOTE: FINAL STEP: About to pass the estimate object back to the assigned variable.")
         return estimate
 
     def do(self, x, identified_estimand, method_name=None,  method_params=None):

--- a/dowhy/do_why.py
+++ b/dowhy/do_why.py
@@ -135,7 +135,6 @@ class CausalModel:
             and other method-dependent information
 
         """
-        print(f"NOTE: Entered **estimate_effect** of **CausalModel** in file **do_why.py**")
         if method_name is None:
             pass
         else:
@@ -150,7 +149,6 @@ class CausalModel:
             self.logger.warning("No valid identified estimand for using instrumental variables method")
             estimate = CausalEstimate(None, None, None)
         else:
-            print(f"NOTE: causal_estimator_class: {causal_estimator_class}.")
             causal_estimator = causal_estimator_class(
                 self._data,
                 identified_estimand,
@@ -158,15 +156,12 @@ class CausalModel:
                 test_significance=test_significance,
                 params=method_params
             )
-            print(f"NOTE: causal_estimator: {causal_estimator}.")
-            print(f"NOTE: About to call **causal_estimator.estimate_effect()** in **CausalModel** in file **do_why.py** with {num_simulations} simulations.")
+            
             estimate = causal_estimator.estimate_effect(num_simulations)
-            print(f"NOTE: Received **estimate** object with value {estimate.value} from **CausalEstimator** in **causal_estimator.py**")
             estimate.add_params(
                 estimand_type=identified_estimand.estimand_type,
                 estimator_class=causal_estimator_class
             )
-            print(f"NOTE: FINAL STEP: About to pass the estimate object back to the assigned variable.")
         return estimate
 
     def do(self, x, identified_estimand, method_name=None,  method_params=None):


### PR DESCRIPTION
In cases of larger datasets 1000 simulations can take a long time - num_simulations parameter added to estimate_effect method allows user to reduce (or increase!) cycles and therefore runtime. 

No further checks have been added to the code - test_significance method of CausalEstimator already looks for a num_simulations attribute and sets parameter value should it not exist. Furthermore, num_simulations=1000 was set as a default for the method, but this was not exposed to the user in the estimate_effect() method.