### PR TITLE
Improve iv

### DIFF
--- a/dowhy/causal_estimators/instrumental_variable_estimator.py
+++ b/dowhy/causal_estimators/instrumental_variable_estimator.py
@@ -45,10 +45,9 @@ class InstrumentalVariableEstimator(CausalEstimator):
             deno = x1_z - x0_z
             iv_est = num / deno
         else:
-            # Obtain estimate by Pearl (1995) ratio estimator.
-            # y = x+ u; multiply both sides by z and take expectation.
-            num_yz = np.dot(self._outcome, instrument)
-            deno_xz = np.dot(self._treatment, instrument)
+            # Obtain estimate by 2SLS estimator: Cov(y,z) / Cov(x,z)
+            num_yz = np.cov(self._outcome, instrument)[0, 1]
+            deno_xz = np.cov(self._outcome, instrument)[0, 1]
             iv_est = num_yz / deno_xz
 
         estimate = CausalEstimate(estimate=iv_est,

--- a/tests/causal_estimators/base.py
+++ b/tests/causal_estimators/base.py
@@ -10,7 +10,7 @@ class TestEstimator(object):
         self._Estimator = Estimator
         print(self._error_tolerance)
 
-    def average_treatment_effect_test(self, dataset="linear", beta=10,
+    def average_treatment_effect_test_binary(self, dataset="linear", beta=10,
             num_common_causes=1, num_instruments=1, num_samples=100000,
             treatment_is_binary=True):
         data = dowhy.datasets.linear_dataset(beta=beta,
@@ -37,17 +37,51 @@ class TestEstimator(object):
         )
         true_ate = data["ate"]
         ate_estimate = estimator_ate.estimate_effect()
-        error = ate_estimate.value - true_ate
+        error = abs(ate_estimate.value - true_ate)
         print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
             error, self._error_tolerance * 100, ate_estimate.value, true_ate)
         )
-        res = True if (error < true_ate * self._error_tolerance) else False
+        res = True if (error < abs(true_ate) * self._error_tolerance) else False
         assert res
 
+    def average_treatment_effect_test_continuous(self, dataset="linear", beta=1,
+            num_common_causes=3, num_instruments=2, num_samples=100000,
+            treatment_is_binary=False):
+        data = dowhy.datasets.linear_dataset(beta=beta,
+                                             num_common_causes=num_common_causes,
+                                             num_instruments=num_instruments,
+                                             num_samples=num_samples,
+                                             treatment_is_binary=treatment_is_binary)
+        model = CausalModel(
+            data=data['df'],
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            graph=data["gml_graph"],
+            proceed_when_unidentifiable=True,
+            test_significance=None
+        )
+        target_estimand = model.identify_effect()
+        estimator_ate = self._Estimator(
+            data['df'],
+            identified_estimand=target_estimand,
+            treatment=data["treatment_name"],
+            outcome=data["outcome_name"],
+            test_significance=None
+        )
+        true_ate = data["ate"]
+        ate_estimate = estimator_ate.estimate_effect()
+        error = abs(ate_estimate.value - true_ate)
+        print("Error in ATE estimate = {0} with tolerance {1}%. Estimated={2},True={3}".format(
+            error, self._error_tolerance * 100, ate_estimate.value, true_ate)
+        )
+        res = True if (error < abs(true_ate) * self._error_tolerance) else False
+        assert res
+
+
     def average_treatment_effect_testsuite(self, tests_to_run="all"):
-        self.average_treatment_effect_test(num_common_causes=1)
+        self.average_treatment_effect_test_binary(num_common_causes=1)
         if tests_to_run != "atleast-one-common-cause":
-            self.average_treatment_effect_test(num_common_causes=0)
+            self.average_treatment_effect_test_binary(num_common_causes=0)
 
     def custom_data_average_treatment_effect_test(self, data):
         model = CausalModel(

--- a/tests/causal_estimators/test_instrumental_variable_estimator.py
+++ b/tests/causal_estimators/test_instrumental_variable_estimator.py
@@ -10,4 +10,5 @@ class TestInstrumentalVariableEstimator(object):
                               (0.2, InstrumentalVariableEstimator)])
     def test_average_treatment_effect(self, error_tolerance, Estimator):
         estimator_tester = TestEstimator(error_tolerance, Estimator)
-        estimator_tester.average_treatment_effect_test()
+        estimator_tester.average_treatment_effect_test_binary()
+        estimator_tester.average_treatment_effect_test_continuous()


### PR DESCRIPTION
Hi, this is great work and I hope that I can make some useful contributions! This is my first PR with 3 changes: 

1. FIx the IV estimate for the continuous variable case. My understanding is that the standard IV estimate for the ATE is R_{yz} / R_{xz}, where R_{yz} is the coefficient for Z in a regression of Y on Z and R_{xz} is the coefficient for Z in a regression of X on Z. This is equivalent to Cov(Y, Z) / Cov(X, Z). 
The current implementation for the IV estimate is mean(y*z) / mean(x*z) which will be close to Cov(Y, Z) / Cov(X, Z) when Y, X, Z have means close to 0. 

I compared the accuracy of the current IV estimate with the one obtained by dividing covariance and found that in 100 simulations of the linear dataset with beta = 1, the current IV estimate has more than 10% error in about 70% of the time, whereas the IV estimate above has more than 10% only about 10% of the time: 

![image](https://user-images.githubusercontent.com/11097965/61834053-479fea00-ae2b-11e9-8c1f-fec6e4dea45e.png)

2. The test case for ATE should be using absolute values when checking whether the error exceeds the specified threshold. For example, if true value = 1 and estimate = -0.5, then the test currently will pass with an error threshold of 10% because err = -0.5 - 1 = -1.5 < 1*0.1. Using absolute values, we have err = abs(-0.5 - 1) = 1.5 which is not less than 1*0.1. 

3. I also added a test case for the ATE when the IV is continuous. 