### PR TITLE
Friendlier message for sampler import error

### DIFF
--- a/dowhy/api/causal_data_frame.py
+++ b/dowhy/api/causal_data_frame.py
@@ -59,7 +59,7 @@ class CausalAccessor(object):
 
         :param x: str, list, dict: The causal state on which to intervene, and (optional) its interventional value(s).
         :param method: The inference method to use with the sampler. Currently, `'mcmc'`, `'weighting'`, and
-        `'kernel_density'` are supported.
+        `'kernel_density'` are supported. The `mcmc` sampler requires `pymc3>=3.7`.
         :param num_cores: int: if the inference method only supports sampling a point at a time, this will parallelize
         sampling.
         :param variable_types: dict: The dictionary containing the variable types. Must contain the union of the causal

--- a/dowhy/do_samplers/__init__.py
+++ b/dowhy/do_samplers/__init__.py
@@ -3,18 +3,19 @@ from importlib import import_module
 
 from dowhy.do_sampler import DoSampler
 
+PACKAGE_NAME = "dowhy.do_samplers"
 
 def get_class_object(method_name, *args, **kwargs):
     # from https://www.bnmetrics.com/blog/factory-pattern-in-python3-simple-version
     try:
         module_name = method_name
         class_name = string.capwords(method_name, "_").replace('_', '')
-
-        do_sampler_module = import_module('.' + module_name,
-                                         package="dowhy.do_samplers")
+        do_sampler_module = import_module('.' + module_name, package=PACKAGE_NAME)
         do_sampler_class = getattr(do_sampler_module, class_name)
         assert issubclass(do_sampler_class, DoSampler)
 
-    except (AttributeError, AssertionError, ImportError):
+    except (AttributeError, AssertionError, ImportError) as e:
+        if isinstance(e, ImportError) and e.name != PACKAGE_NAME + '.' + module_name:
+            raise e
         raise ImportError('{} is not an existing do sampler.'.format(method_name))
     return do_sampler_class


### PR DESCRIPTION
This is for surfacing import errors caused by the sampler file itself,
or other dependencies (such as PyMC3 for mcmc_sampler).

Instead of a confusing error message "xxxx is not an existing do
sampler", it actually shows what is the real Python module that is
missing.

Possibly fixing #55.