### PR TITLE
Fix mcmc_sampler causal_model argument

### DIFF
--- a/dowhy/do_samplers/mcmc_sampler.py
+++ b/dowhy/do_samplers/mcmc_sampler.py
@@ -20,7 +20,7 @@ class McmcSampler(DoSampler):
         self.point_sampler = False
         self.sampler = self._construct_sampler()
 
-        self.g = kwargs.get('causal_model', None)._graph.get_unconfounded_observed_subgraph()
+        self.g = causal_model._graph.get_unconfounded_observed_subgraph()
         g_fit = nx.DiGraph(self.g)
         _, self.fit_trace = self.fit_causal_model(g_fit,
                                                   self._data,


### PR DESCRIPTION
`causal_model` will never be in `kwargs` because it has been changed to an explicit named parameter. 