### PR TITLE
Modified CausalModel import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,8 +119,7 @@ pandas dataframe df that contains the data:
 
 .. code:: python
 
-    import dowhy
-    from dowhy.do_why import CausalModel
+    from dowhy import CausalModel
     import dowhy.datasets
 
     # Load some sample data

--- a/dowhy/__init__.py
+++ b/dowhy/__init__.py
@@ -1,4 +1,6 @@
 from os import path
+from dowhy.do_why import CausalModel
+
 
 here = path.abspath(path.dirname(__file__))
 # Loading version number

--- a/tests/causal_estimators/base.py
+++ b/tests/causal_estimators/base.py
@@ -1,6 +1,6 @@
 import dowhy.datasets
 
-from dowhy.do_why import CausalModel
+from dowhy import CausalModel
 
 
 class TestEstimator(object):

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -1,6 +1,6 @@
 import dowhy.datasets
 
-from dowhy.do_why import CausalModel
+from dowhy import CausalModel
 
 
 class TestRefuter(object):


### PR DESCRIPTION
Added import to `dowhy.__init__.py` so that `CausalModel` can be imported directly from `dowhy`.

For example, with this change the [top README example](https://github.com/microsoft/dowhy#sample-causal-inference-analysis-in-dowhy) would start with
```
from dowhy import CausalModel
import dowhy.datasets
```

Does this address one of the cards in the "Bug fixes"?

Also, what do you think about changing `do_why.py` to something like `causal_model.py`?