### PR TITLE
Adding a few placeholder methods

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -37,6 +37,9 @@ class CausalEstimator:
 
         self.logger = logging.getLogger(__name__)
 
+    def _estimate_effect(self):
+        raise NotImplementedError
+
     def estimate_effect(self):
         """TODO.
 
@@ -74,6 +77,9 @@ class CausalEstimator:
         est = self._do(x)
 
         return est
+
+    def construct_symbolic_estimator(self, estimand):
+        raise NotImplementedError
 
     def test_significance(self, estimate, num_simulations=1000):
         """Test statistical significance of obtained estimate.

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -16,6 +16,9 @@ class CausalRefuter:
             np.random.seed(self._random_seed)
         self.logger = logging.getLogger(__name__)
 
+    def refute_estimate(self):
+        raise NotImplementedError
+
 
 class CausalRefutation:
 

--- a/dowhy/data_transformer.py
+++ b/dowhy/data_transformer.py
@@ -5,4 +5,4 @@ class DimensionalityReducer:
         self._ndims = ndims
 
     def reduce(self, target_dimensions=None):
-        pass
+        raise NotImplementedError

--- a/tests/test_causal_estimator.py
+++ b/tests/test_causal_estimator.py
@@ -1,5 +1,23 @@
 import unittest
 
+import pytest
+
+from dowhy.causal_estimator import CausalEstimator
+
+
+class MockEstimator(CausalEstimator):
+    pass
+
+
+def test_causal_estimator_placeholder_methods():
+    estimator = MockEstimator(None, None, [None], [None], None)
+    with pytest.raises(NotImplementedError):
+        estimator._estimate_effect()
+    with pytest.raises(NotImplementedError):
+        estimator._do(None)
+    with pytest.raises(NotImplementedError):
+        estimator.construct_symbolic_estimator(None)
+
 
 class TestCausalEstimator(unittest.TestCase):
     def setUp(self):

--- a/tests/test_causal_refuter.py
+++ b/tests/test_causal_refuter.py
@@ -1,0 +1,14 @@
+import pytest
+
+from dowhy.causal_refuter import CausalRefuter
+from dowhy.causal_identifier import IdentifiedEstimand
+
+
+class MockRefuter(CausalRefuter):
+	pass
+
+
+def test_causal_refuter_placeholder_method():
+	refuter = MockRefuter(None, IdentifiedEstimand(None, None), None)
+	with pytest.raises(NotImplementedError):
+		refuter.refute_estimate()

--- a/tests/test_data_transformer.py
+++ b/tests/test_data_transformer.py
@@ -1,0 +1,13 @@
+import pytest
+
+from dowhy.data_transformer import DimensionalityReducer
+
+
+class MockReducer(DimensionalityReducer):
+	pass
+
+
+def test_dimensionality_reducer_placeholder_methods():
+	reducer = MockReducer(None, None)
+	with pytest.raises(NotImplementedError):
+		reducer.reduce()


### PR DESCRIPTION
This attempts to resolve #78

I added or modified these methods, to raise `NotImplementedError`
- `DimensionalityReducer.reduce`
- `CausalRefuter.refute_estimate`, because `CausalModel` assumes a refuter has this method
- `CausalEstimator._estimate_effect`, because it is referred to by `CausalEstimator.estimate_effect`
- `CausalEstimator.construct_symbolic_estimator`, because all of the classes in the `causal_estimators/` directory implement the method

I also made an attempt at writing tests to verify that subclasses need to implement these methods.