### PR TITLE
Add seed for random numbers

### DIFF
--- a/tests/causal_estimators/test_instrumental_variable_estimator.py
+++ b/tests/causal_estimators/test_instrumental_variable_estimator.py
@@ -4,7 +4,7 @@ import itertools
 from dowhy.causal_estimators.instrumental_variable_estimator import InstrumentalVariableEstimator
 from .base import TestEstimator
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestInstrumentalVariableEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator",
         "num_common_causes", "num_instruments",

--- a/tests/causal_estimators/test_linear_regression_estimator.py
+++ b/tests/causal_estimators/test_linear_regression_estimator.py
@@ -3,7 +3,7 @@ import pytest
 from dowhy.causal_estimators.linear_regression_estimator import LinearRegressionEstimator
 from .base import TestEstimator
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestLinearRegressionEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator",
         "num_common_causes", "num_instruments",

--- a/tests/causal_estimators/test_propensity_score_matching_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_matching_estimator.py
@@ -9,7 +9,7 @@ class TestPropensityScoreMatchingEstimator(object):
         "num_common_causes", "num_instruments",
         "num_effect_modifiers", "num_treatments",
         "treatment_is_binary", "outcome_is_binary"],
-                             [(0.1, PropensityScoreMatchingEstimator, [1,2], [0], [0,], [1,], [True,], [False,]),])
+                             [(0.3, PropensityScoreMatchingEstimator, [1,2], [0], [0,], [1,], [True,], [False,]),])
     def test_average_treatment_effect(self, error_tolerance, Estimator,
             num_common_causes, num_instruments, num_effect_modifiers,
             num_treatments, treatment_is_binary, outcome_is_binary

--- a/tests/causal_estimators/test_propensity_score_matching_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_matching_estimator.py
@@ -3,7 +3,7 @@ import pytest
 
 from .base import TestEstimator
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestPropensityScoreMatchingEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator",
         "num_common_causes", "num_instruments",

--- a/tests/causal_estimators/test_propensity_score_stratification_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_stratification_estimator.py
@@ -3,7 +3,7 @@ import pytest
 from dowhy.causal_estimators.propensity_score_stratification_estimator import PropensityScoreStratificationEstimator
 from .base import TestEstimator
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestPropensityScoreStratificationEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator",
         "num_common_causes", "num_instruments",

--- a/tests/causal_estimators/test_propensity_score_weighting_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_weighting_estimator.py
@@ -7,7 +7,7 @@ from .base import TestEstimator
 
 from sklearn.linear_model import LinearRegression
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestPropensityScoreWeightingEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator",
         "num_common_causes", "num_instruments",

--- a/tests/causal_estimators/test_regression_discontinuity_estimator.py
+++ b/tests/causal_estimators/test_regression_discontinuity_estimator.py
@@ -3,7 +3,7 @@ import pytest
 from dowhy.causal_estimators.regression_discontinuity_estimator import RegressionDiscontinuityEstimator
 from .base import TestEstimator
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestRegressionDiscontinuityEstimator(object):
     @pytest.mark.parametrize(["error_tolerance", "Estimator",
         "num_common_causes", "num_instruments",

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from .base import TestRefuter
 
+@pytest.mark.usefixtures("fixed_seed")
 class TestAddUnobservedCommonCauseRefuter(object):
     @pytest.mark.parametrize(["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
                              [(0.01, "backdoor.propensity_score_matching", 0.01, 0.02),])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+import numpy
+import random as rand
+
+@pytest.fixture
+def fixed_seed():
+    rand.seed(0)
+    numpy.random.seed(0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,4 @@ import random as rand
 def fixed_seed():
     rand.seed(0)
     numpy.random.seed(0)
+

--- a/tests/do_sampler/test_pandas_do_api.py
+++ b/tests/do_sampler/test_pandas_do_api.py
@@ -7,7 +7,7 @@ import dowhy.api
 
 from sklearn.linear_model import LinearRegression
 
-
+@pytest.mark.usefixtures("fixed_seed")
 class TestPandasDoAPI(object):
     @pytest.mark.parametrize(["N", "error_tolerance"],
                              [(10000, 0.1),])


### PR DESCRIPTION
Add fixture to fix seed
- Add ```conftest.py``` to define seed
- Add fixture to class to fix random generation

The advantage of this lies with the fact it allows us to have reproducible tests. Seeding allows us to deal with the same set of random numbers.