### PR TITLE
Clean up existing refuters and add Dummy Outcome Refuter

### DIFF
--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -89,7 +89,7 @@ class CausalRefuter:
                 p_value = self.perform_bootstrap_test(estimate, simulations)
 
             else:
-                self.logger.warn("We assume a Normal Distribution as the sample has less than 100 examples.\n \
+                self.logger.warning("We assume a Normal Distribution as the sample has less than 100 examples.\n \
                 Note: The underlying distribution may not be Normal. We assume that it approaches normal with the increase in sample size.")
             
                 # Perform Normal Tests of Significance with the original estimate and the set of refutations
@@ -169,8 +169,8 @@ class CausalRefutation:
     """
 
     def __init__(self, estimated_effect, new_effect, refutation_type):
-        self.estimated_effect = estimated_effect,
-        self.new_effect = new_effect,
+        self.estimated_effect = estimated_effect
+        self.new_effect = new_effect
         self.refutation_type = refutation_type
 
         self.refutation_result = None

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -126,7 +126,7 @@ class CausalRefuter:
         # Sort the simulations
         simulations.sort()
         # Obtain the median value
-        median_refute_values= simulations[int(num_simulations)/2]
+        median_refute_values= simulations[int(num_simulations/2)]
 
         # Performing a two sided test
         if estimate.value > median_refute_values:
@@ -181,7 +181,7 @@ class CausalRefutation:
                 self.refutation_type, self.estimated_effect, self.new_effect
             )
         else:
-            return "{0}\nEstimated effect:{1}\nNew effect:{2}\np value{3}\n".format(
+            return "{0}\nEstimated effect:{1}\nNew effect:{2}\np value:{3}\n".format(
                 self.refutation_type, self.estimated_effect, self.new_effect, self.refutation_result['p_value']
             )
     

--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -87,7 +87,7 @@ class AddUnobservedCommonCause(CausalRefuter):
                         refute = CausalRefutation(self._estimate.value, new_effect.value,
                                                 refutation_type="Refute: Add an Unobserved Common Cause")
                         self.logger.debug(refute)
-                        results_matrix[i][j] = refute.estimated_effect[0] # Populate the results
+                        results_matrix[i][j] = refute.estimated_effect # Populate the results
                 
                 fig = plt.figure(figsize=(6,5))
                 left, bottom, width, height = 0.1, 0.1, 0.8, 0.8
@@ -115,7 +115,7 @@ class AddUnobservedCommonCause(CausalRefuter):
                     refute = CausalRefutation(self._estimate.value, new_effect.value,
                                             refutation_type="Refute: Add an Unobserved Common Cause")
                     self.logger.debug(refute)
-                    outcomes[i] = refute.estimated_effect[0] # Populate the results
+                    outcomes[i] = refute.estimated_effect # Populate the results
 
                 fig = plt.figure(figsize=(6,5))
                 left, bottom, width, height = 0.1, 0.1, 0.8, 0.8
@@ -141,7 +141,7 @@ class AddUnobservedCommonCause(CausalRefuter):
                     refute = CausalRefutation(self._estimate.value, new_effect.value,
                                             refutation_type="Refute: Add an Unobserved Common Cause")
                     self.logger.debug(refute)
-                    outcomes[i] = refute.estimated_effect[0] # Populate the results
+                    outcomes[i] = refute.estimated_effect # Populate the results
                 
                 fig = plt.figure(figsize=(6,5))
                 left, bottom, width, height = 0.1, 0.1, 0.8, 0.8

--- a/dowhy/causal_refuters/bootstrap_refuter.py
+++ b/dowhy/causal_refuters/bootstrap_refuter.py
@@ -61,7 +61,7 @@ class BootstrapRefuter(CausalRefuter):
         # Ideally that should be the case as bootstrapping should not have a significant effect on the ability
         # of the treatment to affect the outcome
         refute.add_significance_test_results(
-            self.test_significance(self._estimate.value, sample_estimates)
+            self.test_significance(self._estimate, sample_estimates)
         )
 
         return refute

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -57,7 +57,7 @@ class DataSubsetRefuter(CausalRefuter):
         # Ideally that should be the case as choosing a subset should not have a significant effect on the ability
         # of the treatment to affect the outcome
         refute.add_significance_test_results(
-            self.test_significance(self._estimate.value, sample_estimates)
+            self.test_significance(self._estimate, sample_estimates)
         )
 
         return refute

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -33,7 +33,7 @@ class DummyOutcomeRefuter(CausalRefuter):
         else:
             logging.basicConfig(level=logging.INFO)
         
-        self.logger - logging.getLogger(__name__)
+        self.logger = logging.getLogger(__name__)
 
     def refute_estimate(self):
 
@@ -68,22 +68,22 @@ class DummyOutcomeRefuter(CausalRefuter):
         self.logger.debug(new_data[0:10])
 
         new_estimator = self.get_estimator_object(new_data, identified_estimand, self._estimate)
-        new_effect = new_estimator.esitmate_effect()
-        sample_estimates[index] = new_effect.values
+        new_effect = new_estimator.estimate_effect()
+        sample_estimates[index] = new_effect.value
 
-    refute = CausalRefutation(self._estimate.value,
-                                       np.mean(sample_estimates),
-                                       refutation_type="Refute: Use a Dummy Outcome")
-    
-    # Note: We hardcode the estimate value to ZERO as we want to check if it falls in the distribution of the refuter
-    # Ideally we should expect that ZERO should fall in the distribution of the effect estimates as we have severed any causal 
-    # relationship between the treatment and the outcome.
+        refute = CausalRefutation(self._estimate.value,
+                                        np.mean(sample_estimates),
+                                        refutation_type="Refute: Use a Dummy Outcome")
+        
+        # Note: We hardcode the estimate value to ZERO as we want to check if it falls in the distribution of the refuter
+        # Ideally we should expect that ZERO should fall in the distribution of the effect estimates as we have severed any causal 
+        # relationship between the treatment and the outcome.
 
-    dummy_estimator = copy.deepcopy(self._estimate)
-    dummy_estimator.value = 0
+        dummy_estimator = copy.deepcopy(self._estimate)
+        dummy_estimator.value = 0
 
-    refute.add_significance_test_results(
-        self.test_significance(dummy_estimator, sample_estimates)
-    )
+        refute.add_significance_test_results(
+            self.test_significance(dummy_estimator, sample_estimates)
+        )
 
-    return refute
+        return refute

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -1,0 +1,89 @@
+import copy
+
+import numpy as np
+import logging
+
+from dowhy.causal_refuter import CausalRefutation
+from dowhy.causal_refuter import CausalRefuter
+
+class DummyOutcomeRefuter(CausalRefuter):
+    """Refute an estimate by replacing the outcome with a randomly generated variable.
+
+    Supports additional parameters that can be specified in the refute_estimate() method.
+
+    - 'dummy_outcome_type': str, None by default
+    Default is to generate random values for the treatment. If palcebo_type is "permute",
+    then the original treatement values are permuted by row.
+    - 'num_simulations': int, CausalRefuter.DEFAULT_NUM_SIMULATIONS by default
+    The number of simulations to be run
+    - 'random_state': int, RandomState, None by default
+    The seed value to be added if we wish to repeat the same random behavior. If we want to repeat the
+    same behavior we push the same seed in the psuedo-random generator
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._dummy_outcome_type = kwargs.pop("placebo_type", None)
+        if self._dummy_outcome_type is None:
+            self._dummy_outcome_type = "Random Data"
+        self._num_simulations = kwargs.pop("num_simulations", CausalRefuter.DEFAULT_NUM_SIMULATIONS)
+        self._random_state = kwargs.pop("random_state", None)
+
+        if 'logging_level' in kwargs:
+            logging.basicConfig(level=kwargs['logging_level'])
+        else:
+            logging.basicConfig(level=logging.INFO)
+        
+        self.logger - logging.getLogger(__name__)
+
+    def refute_estimate(self):
+
+        # We need to change the identified estimand
+        # We thus, make a copy. This is done as we don't want
+        # to change the original DataFrame
+        identified_estimand = copy.deepcopy(self._target_estimand)
+        identified_estimand.outcome_variable = ["dummy_outcome"]
+
+        sample_estimates = np.zeros(self._num_simulations)
+        self.logger.info("Refutation over {} simulated datasets of {} treatment"
+                        .format(self._num_simulations
+                        ,self._dummy_outcome_type)
+                        )
+        num_rows =  self._data.shape[0]
+
+        for index in range(self._num_simulations):
+
+            if self._dummy_outcome_type == "permute":
+                if self._random_state is None:
+                    new_outcome = self._data[self._outcome_name].sample(frac=1).values
+                else:
+                    new_outcome = self._data[self._outcome_name].sample(frac=1,
+                                                                random_state=self._random_state).values
+            else:
+                new_outcome = np.random.randn(num_rows)
+
+        # Create a new column in the data by the name of dummy_outcome
+        new_data = self._data.assign(dummy_outcome=new_outcome)
+
+        # Sanity check the data
+        self.logger.debug(new_data[0:10])
+
+        new_estimator = self.get_estimator_object(new_data, identified_estimand, self._estimate)
+        new_effect = new_estimator.esitmate_effect()
+        sample_estimates[index] = new_effect.values
+
+    refute = CausalRefutation(self._estimate.value,
+                                       np.mean(sample_estimates),
+                                       refutation_type="Refute: Use a Dummy Outcome")
+    
+    # Note: We hardcode the estimate value to ZERO as we want to check if it falls in the distribution of the refuter
+    # Ideally we should expect that ZERO should fall in the distribution of the effect estimates as we have severed any causal 
+    # relationship between the treatment and the outcome.
+
+    dummy_estimator = copy.deepcopy(self._estimate)
+    dummy_estimator.value = 0
+
+    refute.add_significance_test_results(
+        self.test_significance(dummy_estimator, sample_estimates)
+    )
+
+    return refute

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -74,8 +74,11 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         # Note: We hardcode the estimate value to ZERO as we want to check if it falls in the distribution of the refuter
         # Ideally we should expect that ZERO should fall in the distribution of the effect estimates as we have severed any causal
         # relationship between the treatment and the outcome.
+
+        dummy_estimator = copy.deepcopy(self._estimate)
+        dummy_estimator.value = 0
         refute.add_significance_test_results(
-            self.test_significance(0, sample_estimates)
+            self.test_significance(dummy_estimator, sample_estimates)
         )        
         
         return refute

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -63,7 +63,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
                         )
 
         num_rows = self._data.shape[0]
-
+        treatment_name = self._treatment_name[0] # Extract the name of the treatment variable
         type_dict = dict( self._data.dtypes )
 
         for index in range(self._num_simulations):
@@ -75,7 +75,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
                     new_treatment = self._data[self._treatment_name].sample(frac=1, 
                                                                     random_state=self._random_state).values                    
             else:
-                if 'float' in type_dict[self._treatment_name].name :
+                if 'float' in type_dict[treatment_name].name :
                     self.logger.info("Using a Normal Distribution with Mean:{} and Variance:{}"
                                      .format(PlaceboTreatmentRefuter.DEFAULT_MEAN_OF_NORMAL
                                      ,PlaceboTreatmentRefuter.DEFAULT_STD_DEV_OF_NORMAL)
@@ -83,7 +83,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
                     new_treatment = np.random.randn(num_rows)*PlaceboTreatmentRefuter.DEFAULT_STD_DEV_OF_NORMAL + \
                                     PlaceboTreatmentRefuter.DEFAULT_MEAN_OF_NORMAL 
                 
-                elif 'bool' in type_dict[self._treatment_name].name :
+                elif 'bool' in type_dict[treatment_name].name :
                     self.logger.info("Using a Binomial Distribution with {} trials and {} probability of success"
                                     .format(PlaceboTreatmentRefuter.DEFAULT_NUMBER_OF_TRIALS
                                     ,PlaceboTreatmentRefuter.DEFAULT_PROBABILITY_OF_BINOMIAL)
@@ -92,17 +92,17 @@ class PlaceboTreatmentRefuter(CausalRefuter):
                                                        PlaceboTreatmentRefuter.DEFAULT_PROBABILITY_OF_BINOMIAL,
                                                        num_rows).astype(bool)
                 
-                elif 'int' in type_dict[self._treatment_name].name :
+                elif 'int' in type_dict[treatment_name].name :
                     self.logger.info("Using a Discrete Uniform Distribution lying between {} and {}"
-                    .format(self._data[self._treatment_name].min()
-                    ,self._data[self._treatment_name].max())
+                    .format(self._data[treatment_name].min()
+                    ,self._data[treatment_name].max())
                     )
-                    new_treatment = np.random.randint(low=self._data[self._target_estimand].min(),
-                                                      high=self._data[self._treatment_name].max(),
+                    new_treatment = np.random.randint(low=self._data[treatment_name].min(),
+                                                      high=self._data[treatment_name].max(),
                                                       size=num_rows)
 
-                elif 'category' in type_dict[self._treatment_name].name :
-                    categories = self._data[self._treatment_name].unique()
+                elif 'category' in type_dict[treatment_name].name :
+                    categories = self._data[treatment_name].unique()
                     self.logger.info("Using a Discrete Uniform Distribution with the following categories:{}"
                     .format(categories))
                     sample = np.random.choice(categories, size=num_rows)
@@ -114,7 +114,6 @@ class PlaceboTreatmentRefuter(CausalRefuter):
             # Sanity check the data
             self.logger.debug(new_data[0:10])
 
-            
             new_estimator = self.get_estimator_object(new_data, identified_estimand, self._estimate)
             new_effect = new_estimator.estimate_effect()
             sample_estimates[index] = new_effect.value

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -1,6 +1,7 @@
 import copy
 
 import numpy as np
+import logging 
 
 from dowhy.causal_refuter import CausalRefutation
 from dowhy.causal_refuter import CausalRefuter
@@ -27,6 +28,14 @@ class PlaceboTreatmentRefuter(CausalRefuter):
             self._placebo_type = "Random Data"
         self._num_simulations = kwargs.pop("num_simulations",CausalRefuter.DEFAULT_NUM_SIMULATIONS)
         self._random_state = kwargs.pop("random_state",None)
+
+        if 'logging_level' in kwargs:
+            logging.basicConfig(level=kwargs['logging_level'])
+        else:
+            logging.basicConfig(level=logging.INFO)
+
+        self.logger = logging.getLogger(__name__)
+
 
     def refute_estimate(self):
 
@@ -65,7 +74,6 @@ class PlaceboTreatmentRefuter(CausalRefuter):
             new_estimator = self.get_estimator_object(new_data, identified_estimand, self._estimate)
             new_effect = new_estimator.estimate_effect()
             sample_estimates[index] = new_effect.value
-        
 
         refute = CausalRefutation(self._estimate.value, 
                                   np.mean(sample_estimates),
@@ -77,8 +85,10 @@ class PlaceboTreatmentRefuter(CausalRefuter):
 
         dummy_estimator = copy.deepcopy(self._estimate)
         dummy_estimator.value = 0
+
         refute.add_significance_test_results(
             self.test_significance(dummy_estimator, sample_estimates)
         )        
         
+        print("number of sample estimates ",len(sample_estimates))
         return refute

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -63,7 +63,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
                                                                     random_state=self._random_state).values                    
             else:
                 new_treatment = np.random.randn(num_rows)
-            
+
             # Create a new column in the data by the name of placebo
             new_data = self._data.assign(placebo=new_treatment)
 
@@ -90,5 +90,4 @@ class PlaceboTreatmentRefuter(CausalRefuter):
             self.test_significance(dummy_estimator, sample_estimates)
         )        
         
-        print("number of sample estimates ",len(sample_estimates))
         return refute

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -18,7 +18,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
     - 'num_simulations': int, CausalRefuter.DEFAULT_NUM_SIMULATIONS by default
     The number of simulations to be run
     - 'random_state': int, RandomState, None by default
-    The seed value to be added if we wish to repeat the same random behavior. If we with to repeat the
+    The seed value to be added if we wish to repeat the same random behavior. If we want to repeat the
     same behavior we push the same seed in the psuedo-random generator
     """
     def __init__(self, *args, **kwargs):
@@ -40,7 +40,7 @@ class PlaceboTreatmentRefuter(CausalRefuter):
     def refute_estimate(self):
 
         # We need to change the identified estimand
-        # This is done as a safety measure, we don't want to change the
+        # We make a copy as a safety measure, we don't want to change the
         # original DataFrame
         identified_estimand = copy.deepcopy(self._target_estimand)
         identified_estimand.treatment_variable = ["placebo"]

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -102,7 +102,7 @@ class TestRefuter(object):
         elif self.refuter_method == "data_subset_refuter":
             ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        method_name=self.refuter_method,
+                                        method_name=self.refuter_method
                                         )
             
             error =  abs(ref.new_effect - ate_estimate.value)
@@ -113,7 +113,7 @@ class TestRefuter(object):
 
             print(ref)
 
-            res = True if (error <  self._error_tolerance) else False
+            res = True if (error <  abs(ate_estimate.value)*self._error_tolerance) else False
             assert res
         
 

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -75,6 +75,25 @@ class TestRefuter(object):
             res = True if (error < abs(ate_estimate.value) * self._error_tolerance) else False
             assert res
 
+        elif self.refuter_method == "placebo_treatment_refuter":
+            ref = model.refute_estimate(target_estimand, 
+                                        ate_estimate,
+                                        placebo_treatment_refuter
+                                        )
+            # This value is hardcoded to be zero as we are runnning this on a linear dataset.
+            # Ordinarily, we should expect this value to be zero.
+            EXPECTED_PLACEBO_VALUE = 0
+            
+            error =  abs(ref.new_effect - ate_estimate.value)
+
+            print("Error in the refuted estimate = {0} with tolderence {1}%. Expected Value={2}, After Refutation={3}".format(
+                error, self._error_tolerence * 100, EXPECTED_PLACEBO_VALUE, refute.new_effect)
+            )
+
+            res = True if (error <  self._error_tolerance)
+            assert res 
+            
+
     def binary_treatment_testsuite(self, tests_to_run="all"):
         self.null_refutation_test(num_common_causes=1)
         if tests_to_run != "atleast-one-common-cause":

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -78,7 +78,7 @@ class TestRefuter(object):
         elif self.refuter_method == "placebo_treatment_refuter":
             ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        placebo_treatment_refuter
+                                        method_name=self.refuter_method
                                         )
             # This value is hardcoded to be zero as we are runnning this on a linear dataset.
             # Ordinarily, we should expect this value to be zero.
@@ -87,11 +87,15 @@ class TestRefuter(object):
             error =  abs(ref.new_effect - ate_estimate.value)
 
             print("Error in the refuted estimate = {0} with tolderence {1}%. Expected Value={2}, After Refutation={3}".format(
-                error, self._error_tolerence * 100, EXPECTED_PLACEBO_VALUE, refute.new_effect)
+                error, self._error_tolerance * 100, EXPECTED_PLACEBO_VALUE, ref.new_effect)
             )
 
-            res = True if (error <  self._error_tolerance)
-            assert res 
+            print(ref)
+
+            res = True if (error <  self._error_tolerance) else False
+            assert res
+
+         
             
 
     def binary_treatment_testsuite(self, tests_to_run="all"):
@@ -101,11 +105,11 @@ class TestRefuter(object):
 
     def continuous_treatment_testsuite(self, tests_to_run="all"):
         self.null_refutation_test(
-                #beta=1,
             num_common_causes=1,
-            #num_instruments=2, num_samples=100000,
             treatment_is_binary=False)
         if tests_to_run != "atleast-one-common-cause":
             self.null_refutation_test(num_common_causes=0,
                     treatment_is_binary=False)
+    
+        
 

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -20,7 +20,7 @@ class TestRefuter(object):
             logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
 
-        print(self._error_tolerance)
+        self.logger.debug(self._error_tolerance)
 
     def null_refutation_test(self, data=None, dataset="linear", beta=10,
             num_common_causes=1, num_instruments=1, num_samples=100000,
@@ -33,6 +33,9 @@ class TestRefuter(object):
                                              num_samples=num_samples,
                                              treatment_is_binary=treatment_is_binary)
 
+        print(data['df'])
+
+        print("")
         model = CausalModel(
             data=data['df'],
             treatment=data["treatment_name"],
@@ -78,25 +81,41 @@ class TestRefuter(object):
         elif self.refuter_method == "placebo_treatment_refuter":
             ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        method_name=self.refuter_method
+                                        method_name=self.refuter_method,
+                                        num_simulations=50
                                         )
             # This value is hardcoded to be zero as we are runnning this on a linear dataset.
             # Ordinarily, we should expect this value to be zero.
             EXPECTED_PLACEBO_VALUE = 0
             
-            error =  abs(ref.new_effect - ate_estimate.value)
+            error =  abs(ref.new_effect - EXPECTED_PLACEBO_VALUE)
 
-            print("Error in the refuted estimate = {0} with tolderence {1}%. Expected Value={2}, After Refutation={3}".format(
+            print("Error in the refuted estimate = {0} with tolerence {1}%. Expected Value={2}, After Refutation={3}".format(
                 error, self._error_tolerance * 100, EXPECTED_PLACEBO_VALUE, ref.new_effect)
             )
 
             print(ref)
 
             res = True if (error <  self._error_tolerance) else False
-            assert res
+            assert False
 
-         
+        elif self.refuter_method == "data_subset_refuter":
+            ref = model.refute_estimate(target_estimand, 
+                                        ate_estimate,
+                                        method_name=self.refuter_method,
+                                        )
             
+            error =  abs(ref.new_effect - ate_estimate.value)
+
+            print("Error in the refuted estimate = {0} with tolerence {1}%. Estimated={2}, After Refutation={3}".format(
+                error, self._error_tolerance * 100, ate_estimate.value, ref.new_effect)
+            )
+
+            print(ref)
+
+            res = True if (error <  self._error_tolerance) else False
+            assert res
+        
 
     def binary_treatment_testsuite(self, tests_to_run="all"):
         self.null_refutation_test(num_common_causes=1)

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -79,10 +79,17 @@ class TestRefuter(object):
             assert res
 
         elif self.refuter_method == "placebo_treatment_refuter":
-            ref = model.refute_estimate(target_estimand, 
+            if treatment_is_binary is True:
+                ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        method_name=self.refuter_method
+                                        method_name=self.refuter_method,
+                                        num_simulations=10
                                         )
+            else:
+                ref = model.refute_estimate(target_estimand, 
+                                            ate_estimate,
+                                            method_name=self.refuter_method
+                                            )
             # This value is hardcoded to be zero as we are runnning this on a linear dataset.
             # Ordinarily, we should expect this value to be zero.
             EXPECTED_PLACEBO_VALUE = 0
@@ -99,10 +106,17 @@ class TestRefuter(object):
             assert res
             
         elif self.refuter_method == "data_subset_refuter":
-            ref = model.refute_estimate(target_estimand, 
+            if treatment_is_binary is True:
+                ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        method_name=self.refuter_method
+                                        method_name=self.refuter_method,
+                                        num_simulations=5
                                         )
+            else:
+                ref = model.refute_estimate(target_estimand, 
+                                            ate_estimate,
+                                            method_name=self.refuter_method
+                                            )
             
             error =  abs(ref.new_effect - ate_estimate.value)
 
@@ -116,10 +130,17 @@ class TestRefuter(object):
             assert res
         
         elif self.refuter_method == "bootstrap_refuter":
-            ref = model.refute_estimate(target_estimand, 
+            if treatment_is_binary is True:
+                ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        method_name=self.refuter_method
+                                        method_name=self.refuter_method,
+                                        num_simulations=5
                                         )
+            else:
+                ref = model.refute_estimate(target_estimand, 
+                                            ate_estimate,
+                                            method_name=self.refuter_method
+                                            )
             
             error =  abs(ref.new_effect - ate_estimate.value)
 

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -81,8 +81,7 @@ class TestRefuter(object):
         elif self.refuter_method == "placebo_treatment_refuter":
             ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
-                                        method_name=self.refuter_method,
-                                        num_simulations=50
+                                        method_name=self.refuter_method
                                         )
             # This value is hardcoded to be zero as we are runnning this on a linear dataset.
             # Ordinarily, we should expect this value to be zero.
@@ -97,8 +96,8 @@ class TestRefuter(object):
             print(ref)
 
             res = True if (error <  self._error_tolerance) else False
-            assert False
-
+            assert res
+            
         elif self.refuter_method == "data_subset_refuter":
             ref = model.refute_estimate(target_estimand, 
                                         ate_estimate,
@@ -116,6 +115,22 @@ class TestRefuter(object):
             res = True if (error <  abs(ate_estimate.value)*self._error_tolerance) else False
             assert res
         
+        elif self.refuter_method == "bootstrap_refuter":
+            ref = model.refute_estimate(target_estimand, 
+                                        ate_estimate,
+                                        method_name=self.refuter_method
+                                        )
+            
+            error =  abs(ref.new_effect - ate_estimate.value)
+
+            print("Error in the refuted estimate = {0} with tolerence {1}%. Estimated={2}, After Refutation={3}".format(
+                error, self._error_tolerance * 100, ate_estimate.value, ref.new_effect)
+            )
+
+            print(ref)
+
+            res = True if (error <  abs(ate_estimate.value)*self._error_tolerance) else False
+            assert res
 
     def binary_treatment_testsuite(self, tests_to_run="all"):
         self.null_refutation_test(num_common_causes=1)

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -132,6 +132,27 @@ class TestRefuter(object):
             res = True if (error <  abs(ate_estimate.value)*self._error_tolerance) else False
             assert res
 
+        elif self.refuter_method == "dummy_outcome_refuter":
+            ref = model.refute_estimate(target_estimand,
+                                         ate_estimate,
+                                         method_name=self.refuter_method
+                                         )
+            
+            # This value is hardcoded to be zero as we are runnning this on a linear dataset.
+            # Ordinarily, we should expect this value to be zero.
+            EXPECTED_DUMMY_OUTCOME_VALUE = 0
+
+            error = abs( ref.new_effect - EXPECTED_DUMMY_OUTCOME_VALUE)
+
+            print("Error in the refuted estimate = {0} with tolerence {1}%. Expected Value={2}, After Refutation={3}".format(
+                error, self._error_tolerance * 100, EXPECTED_DUMMY_OUTCOME_VALUE, ref.new_effect)
+            )
+
+            print(ref)
+
+            res = True if (error <  self._error_tolerance) else False
+            assert res
+
     def binary_treatment_testsuite(self, tests_to_run="all"):
         self.null_refutation_test(num_common_causes=1)
         if tests_to_run != "atleast-one-common-cause":

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -50,29 +50,30 @@ class TestRefuter(object):
         true_ate = data["ate"]
         self.logger.debug(true_ate)
 
+        if self.refuter_method == "add_unobserved_common_cause":
         # To test if there are any exceptions
-        ref = model.refute_estimate(target_estimand, ate_estimate,
-            method_name=self.refuter_method,
-            confounders_effect_on_treatment = self.confounders_effect_on_t,
-            confounders_effect_on_outcome = self.confounders_effect_on_y,
-            effect_strength_on_treatment =self.effect_strength_on_t,
-            effect_strength_on_outcome=self.effect_strength_on_y)
-        self.logger.debug(ref.new_effect)
+            ref = model.refute_estimate(target_estimand, ate_estimate,
+                method_name=self.refuter_method,
+                confounders_effect_on_treatment = self.confounders_effect_on_t,
+                confounders_effect_on_outcome = self.confounders_effect_on_y,
+                effect_strength_on_treatment =self.effect_strength_on_t,
+                effect_strength_on_outcome=self.effect_strength_on_y)
+            self.logger.debug(ref.new_effect)
 
-        # To test if the estimate is identical if refutation parameters are zero
-        refute = model.refute_estimate(target_estimand, ate_estimate,
-            method_name=self.refuter_method,
-            confounders_effect_on_treatment = self.confounders_effect_on_t,
-            confounders_effect_on_outcome = self.confounders_effect_on_y,
-            effect_strength_on_treatment = 0,
-            effect_strength_on_outcome = 0)
-        error = abs(refute.new_effect - ate_estimate.value)
-        
-        print("Error in refuted estimate = {0} with tolerance {1}%. Estimated={2},After Refutation={3}".format(
-            error, self._error_tolerance * 100, ate_estimate.value, refute.new_effect)
-        )
-        res = True if (error < abs(ate_estimate.value) * self._error_tolerance) else False
-        assert res
+            # To test if the estimate is identical if refutation parameters are zero
+            refute = model.refute_estimate(target_estimand, ate_estimate,
+                method_name=self.refuter_method,
+                confounders_effect_on_treatment = self.confounders_effect_on_t,
+                confounders_effect_on_outcome = self.confounders_effect_on_y,
+                effect_strength_on_treatment = 0,
+                effect_strength_on_outcome = 0)
+            error = abs(refute.new_effect - ate_estimate.value)
+            
+            print("Error in refuted estimate = {0} with tolerance {1}%. Estimated={2},After Refutation={3}".format(
+                error, self._error_tolerance * 100, ate_estimate.value, refute.new_effect)
+            )
+            res = True if (error < abs(ate_estimate.value) * self._error_tolerance) else False
+            assert res
 
     def binary_treatment_testsuite(self, tests_to_run="all"):
         self.null_refutation_test(num_common_causes=1)

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -64,3 +64,9 @@ class TestAddUnobservedCommonCauseRefuter(object):
                 effect_strength_on_y = effect_strength_on_y)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
+    @pytest.mark.parametrize(["error_tolerence", "estimator_method"],
+                             [(0.01, "iv.instumental_variable")])
+    def test_refutation_placebo_refuter(self, error_tolerance, estimator_method):
+            refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
+            refuter_tester.continuous_treatment_testsuite(tests_to_run="other") # No common cause
+

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -64,8 +64,8 @@ class TestAddUnobservedCommonCauseRefuter(object):
                 effect_strength_on_y = effect_strength_on_y)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    @pytest.mark.parametrize(["error_tolerence", "estimator_method"],
-                             [(0.01, "iv.instumental_variable")])
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
+                             [(0.01, "iv.instrumental_variable")])
     def test_refutation_placebo_refuter(self, error_tolerance, estimator_method):
             refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
             refuter_tester.continuous_treatment_testsuite(tests_to_run="other") # No common cause

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -65,9 +65,3 @@ class TestAddUnobservedCommonCauseRefuter(object):
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
 
-#      @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-#                              [(0.01, "iv.instrumental_variable")])
-#     def test_refutation_data_subset_refuter(self, error_tolerance, estimator_method):
-#             refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
-#             refuter_tester.continuous_treatment_testsuite(tests_to_run="other") # No common cause
-

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -64,9 +64,10 @@ class TestAddUnobservedCommonCauseRefuter(object):
                 effect_strength_on_y = effect_strength_on_y)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-                             [(0.01, "iv.instrumental_variable")])
-    def test_refutation_placebo_refuter(self, error_tolerance, estimator_method):
-            refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
-            refuter_tester.continuous_treatment_testsuite(tests_to_run="other") # No common cause
+
+#      @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
+#                              [(0.01, "iv.instrumental_variable")])
+#     def test_refutation_data_subset_refuter(self, error_tolerance, estimator_method):
+#             refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
+#             refuter_tester.continuous_treatment_testsuite(tests_to_run="other") # No common cause
 

--- a/tests/causal_refuters/test_bootstrap_refuter.py
+++ b/tests/causal_refuters/test_bootstrap_refuter.py
@@ -6,13 +6,12 @@ from .base import TestRefuter
 class TestDataSubsetRefuter(object):
     @pytest.mark.parametrize(["error_tolerance","estimator_method"],
                               [(0.01, "iv.instrumental_variable")])
-    def test_refutation_data_subset_refuter_continuous(self, error_tolerance, estimator_method):
-        refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
+    def test_refutation_bootstrap_refuter_continuous(self, error_tolerance, estimator_method):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "bootstrap_refuter")
         refuter_tester.continuous_treatment_testsuite() # Run both
 
     @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
                              [(0.01, "backdoor.propensity_score_matching")])
-    def test_refutation_data_subset_refuter_binary(self, error_tolerance, estimator_method):
-        refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
+    def test_refutation_bootstrap_refuter_binary(self, error_tolerance, estimator_method):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "bootstrap_refuter")
         refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause") 
-        

--- a/tests/causal_refuters/test_data_subset_refuter.py
+++ b/tests/causal_refuters/test_data_subset_refuter.py
@@ -1,0 +1,12 @@
+import pytest
+import numpy as np
+from .base import TestRefuter
+
+@pytest.mark.usefixtures("fixed_seed")
+class TestDataSubsetRefuter(object):
+    @pytest.mark.parameterize(["error_tolerance","estimator_method"],
+                              [0.01, "iv.instrument_variable"])
+    def test_refutation_placebo_refuter_continueous(self, error_tolerance, estimator_method):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter"
+        refuter_tester.test_refutation_placebo_refuter_continueous_treatment_testsuite() # Run both
+        

--- a/tests/causal_refuters/test_data_subset_refuter.py
+++ b/tests/causal_refuters/test_data_subset_refuter.py
@@ -7,6 +7,6 @@ class TestDataSubsetRefuter(object):
     @pytest.mark.parameterize(["error_tolerance","estimator_method"],
                               [0.01, "iv.instrument_variable"])
     def test_refutation_placebo_refuter_continueous(self, error_tolerance, estimator_method):
-        refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter"
-        refuter_tester.test_refutation_placebo_refuter_continueous_treatment_testsuite() # Run both
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
+        refuter_tester.continuous_treatment_testsuite() # Run both
         

--- a/tests/causal_refuters/test_data_subset_refuter.py
+++ b/tests/causal_refuters/test_data_subset_refuter.py
@@ -4,9 +4,15 @@ from .base import TestRefuter
 
 @pytest.mark.usefixtures("fixed_seed")
 class TestDataSubsetRefuter(object):
-    @pytest.mark.parameterize(["error_tolerance","estimator_method"],
-                              [0.01, "iv.instrument_variable"])
-    def test_refutation_placebo_refuter_continueous(self, error_tolerance, estimator_method):
+    @pytest.mark.parametrize(["error_tolerance","estimator_method"],
+                              [(0.01, "iv.instrumental_variable")])
+    def test_refutation_data_subset_refuter_continueous(self, error_tolerance, estimator_method):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
         refuter_tester.continuous_treatment_testsuite() # Run both
+
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
+                             [(0.01, "backdoor.propensity_score_matching")])
+    def test_refutation_data_subset_refuter_binary(self, error_tolerance, estimator_method):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "data_subset_refuter")
+        refuter_tester.binary_treatment_testsuite() # Run both
         

--- a/tests/causal_refuters/test_dummy_outcome_refuter.py
+++ b/tests/causal_refuters/test_dummy_outcome_refuter.py
@@ -1,0 +1,11 @@
+import pytest
+import numpy as np
+from .base import TestRefuter
+
+@pytest.mark.usefixtures("fixed_seed")
+class TestDummyOtcomeRefuter(object):
+    @pytest.mark.parametrize(["error_tolerence","estimator_method"],
+                             [(0.03, "iv.instrumental_variable")])
+    def test_refutation_dummy_outcome_refuter(self, error_tolerence, estimator_method):
+        refuter_tester = TestRefuter(error_tolerence, estimator_method, "dummy_outcome_refuter")
+        refuter_tester.continuous_treatment_testsuite()

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -5,7 +5,7 @@ from .base import TestRefuter
 @pytest.mark.usefixtures("fixed_seed")
 class TestPlaceboRefuter(object):
     @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-                             [(0.01, "iv.instrumental_variable")])
+                             [(0.03, "backdoor.linear_regression")])
     def test_refutation_placebo_refuter_continuous(self, error_tolerance, estimator_method):
             refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
             refuter_tester.continuous_treatment_testsuite() # Run both

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -11,7 +11,7 @@ class TestPlaceboRefuter(object):
             refuter_tester.continuous_treatment_testsuite() # Run both
 
     @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-                              [(0.01, "backdoor.propensity_score_matching")])
+                              [(0.05, "backdoor.propensity_score_matching")])
     def test_refutation_placebo_refuter_binary(self, error_tolerance, estimator_method):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
         refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause")

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -6,7 +6,7 @@ from .base import TestRefuter
 class TestPlaceboRefuter(object):
     @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
                              [(0.01, "iv.instrumental_variable")])
-    def test_refutation_placebo_refuter_continueous(self, error_tolerance, estimator_method):
+    def test_refutation_placebo_refuter_continuous(self, error_tolerance, estimator_method):
             refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
             refuter_tester.continuous_treatment_testsuite() # Run both
 
@@ -14,4 +14,4 @@ class TestPlaceboRefuter(object):
                               [(0.01, "backdoor.propensity_score_matching")])
     def test_refutation_placebo_refuter_binary(self, error_tolerance, estimator_method):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
-        refuter_tester.binary_treatment_testsuite() # Run both
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause")

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -1,0 +1,17 @@
+import pytest
+import numpy as np
+from .base import TestRefuter
+
+@pytest.mark.usefixtures("fixed_seed")
+class TestPlaceboRefuter(object):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
+                             [(0.01, "iv.instrumental_variable")])
+    def test_refutation_placebo_refuter_continueous(self, error_tolerance, estimator_method):
+            refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
+            refuter_tester.continuous_treatment_testsuite() # Run both
+
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
+                              [(0.01, "backdoor.propensity_score_matching")])
+    def test_refutation_placebo_refuter_binary(self, error_tolerance, estimator_method):
+        refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
+        refuter_tester.binary_treatment_testsuite() # Run both


### PR DESCRIPTION
This PR fixes the errors detected through testing. The most important being a data type check for adding the placebo data type in the placebo refuter. In addition, it adds a refuter that makes use of a dummy outcome. This allows us to test for the case in which we use instrumental variables to find the effect of the treatment on the outcome.