### PR TITLE
Add super class for propensity score estimators

### DIFF
--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -51,7 +51,7 @@ class PropensityScoreEstimator(CausalEstimator):
             
             Parameters
             -----------
-            recualculate_propensity_score: bool, default False,
+            recalculate_propensity_score: bool, default False,
             This forces the estimator to recalculate the estimate for the propensity score.
         '''
         raise NotImplementedError

--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -10,7 +10,7 @@ class PropensityScoreEstimator(CausalEstimator):
 
         # We need to initialize the model when we create any propensity score estimator
         self._propensity_score_model = None
-        # Check if the input is one-dimensional
+        # Check if the treatment is one-dimensional
         if len(self._treatment_name) > 1:
             error_msg = str(self.__class__) + "cannot handle more than one treatment variable"
             raise Exception(error_msg)

--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pandas as pd
+
+from dowhy.causal_estimator import CausalEstimator
+
+class PropensityScoreEstimator(CausalEstimator):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # We need to initialize the model when we create any propensity score estimator
+        self._propensity_score_model = None
+        # Check if the input is one-dimensional
+        if len(self._treatment_name) > 1:
+            error_msg = str(self.__class__) + "cannot handle more than one treatment variable"
+            raise Exception(error_msg)
+        # Checking if the treatment is binary
+        if not pd.api.types.is_bool_dtype(self._data[self._treatment_name[0]]):
+            error_msg = "Propensity score methods are applicable only for binary treatments"
+            self.logger.error(error_msg)
+            raise Exception(error_msg)
+
+        self.logger.debug("Back-door variables used:" +
+                        ",".join(self._target_estimand.backdoor_variables))
+        
+        self._observed_common_causes_names = self._target_estimand.backdoor_variables
+
+        if self._observed_common_causes_names:
+            self._observed_common_causes = self._data[self._observed_common_causes_names]
+            # Convert the categorical variables into dummy/indicator variables
+            # Basically, this gives a one hot encoding for each category
+            # The first category is taken to be the base line.
+            self._observed_common_causes = pd.get_dummies(self._observed_common_causes, drop_first=True)
+        else:
+            self._observed_common_causes = None
+            error_msg = "No common causes/confounders present. Propensity score based methods are not applicable"
+            self.logger.error(error_msg)
+            raise Exception(error_msg)
+
+    def construct_symbolic_estimator(self, estimand):
+        '''
+            A symbolic string that conveys what each estimator does. 
+            For instance, linear regression is expressed as
+            y ~ bx + e
+        '''
+        raise NotImplementedError
+
+    def _estimate_effect(self, recalculate_propensity_score=False):
+        '''
+            A custom estimator based on the way the propensity score estimates are to be used.
+            
+            Parameters
+            -----------
+            recualculate_propensity_score: bool, default False,
+            This forces the estimator to recalculate the estimate for the propensity score.
+        '''
+        raise NotImplementedError
+

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -33,6 +33,9 @@ class PropensityScoreMatchingEstimator(PropensityScoreEstimator):
             .fit(control['propensity_score'].values.reshape(-1, 1))
         )
         distances, indices = control_neighbors.kneighbors(treated['propensity_score'].values.reshape(-1, 1))
+        self.logger.debug("distances:")
+        self.logger.debug(distances)
+        
         att = 0
         numtreatedunits = treated.shape[0]
         for i in range(numtreatedunits):

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -4,43 +4,22 @@ import pandas as pd
 
 from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimator import CausalEstimator
+from dowhy.causal_estimators.propensity_score_estimator import PropensityScoreEstimator
 
-
-class PropensityScoreMatchingEstimator(CausalEstimator):
+class PropensityScoreMatchingEstimator(PropensityScoreEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # Checking if treatment is one-dimensional
-        if len(self._treatment_name) > 1:
-            error_msg = str(self.__class__) + " cannot handle more than one treatment variable."
-            raise Exception(error_msg)
-        # Checking if treatment is binary
-        if not pd.api.types.is_bool_dtype(self._data[self._treatment_name[0]]):
-            error_msg = "Propensity Score Matching method is only applicable for binary treatments. Try explictly setting dtype=bool for the treatment column."
-            raise Exception(error_msg)
-
-        self.logger.debug("Back-door variables used:" +
-                          ",".join(self._target_estimand.backdoor_variables))
-        self._observed_common_causes_names = self._target_estimand.backdoor_variables
-        if self._observed_common_causes_names:
-            self._observed_common_causes = self._data[self._observed_common_causes_names]
-            self._observed_common_causes = pd.get_dummies(self._observed_common_causes, drop_first=True)
-        else:
-            self._observed_common_causes= None
-            error_msg ="No common causes/confounders present. Propensity score based methods are not applicable"
-            self.logger.error(error_msg)
-            raise Exception(error_msg)
-
-
 
         self.logger.info("INFO: Using Propensity Score Matching Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
         self.logger.info(self.symbolic_estimator)
 
-    def _estimate_effect(self):
-        propensity_score_model = linear_model.LogisticRegression(solver="lbfgs")
-        propensity_score_model.fit(self._observed_common_causes, self._treatment.to_numpy())
-        self._data['propensity_score'] = propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
+    def _estimate_effect(self, recalculate_propensity_score=False):
+        if self._propensity_score_model is None or recalculate_propensity_score is True:
+            propensity_score_model = linear_model.LogisticRegression(solver="lbfgs")
+            propensity_score_model.fit(self._observed_common_causes, self._treatment.to_numpy())
+            self._data['propensity_score'] = propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
 
         # this assumes a binary treatment regime
         treated = self._data.loc[self._data[self._treatment_name[0]] == 1]

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -16,9 +16,9 @@ class PropensityScoreMatchingEstimator(PropensityScoreEstimator):
 
     def _estimate_effect(self, recalculate_propensity_score=False):
         if self._propensity_score_model is None or recalculate_propensity_score is True:
-            propensity_score_model = linear_model.LogisticRegression(solver="lbfgs")
-            propensity_score_model.fit(self._observed_common_causes, self._treatment.to_numpy())
-            self._data['propensity_score'] = propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
+            self._propensity_score_model = linear_model.LogisticRegression(solver="lbfgs")
+            self._propensity_score_model.fit(self._observed_common_causes, self._treatment.to_numpy())
+            self._data['propensity_score'] = self._propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
 
         # this assumes a binary treatment regime
         treated = self._data.loc[self._data[self._treatment_name[0]] == 1]

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -3,7 +3,6 @@ from sklearn.neighbors import NearestNeighbors
 import pandas as pd
 
 from dowhy.causal_estimator import CausalEstimate
-from dowhy.causal_estimator import CausalEstimator
 from dowhy.causal_estimators.propensity_score_estimator import PropensityScoreEstimator
 
 class PropensityScoreMatchingEstimator(PropensityScoreEstimator):

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -33,9 +33,10 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
             self._propensity_score_model = linear_model.LogisticRegression()
             self._propensity_score_model.fit(self._observed_common_causes, self._treatment)
             self._data['ps'] = self._propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
-            # trim propensity score weights
-            self._data['ps'] = np.minimum(self.max_ps_score, self._data['ps'])
-            self._data['ps'] = np.maximum(self.min_ps_score, self._data['ps'])
+        
+        # trim propensity score weights
+        self._data['ps'] = np.minimum(self.max_ps_score, self._data['ps'])
+        self._data['ps'] = np.maximum(self.min_ps_score, self._data['ps'])
 
         # ips ==> (isTreated(y)/ps(y)) + ((1-isTreated(y))/(1-ps(y)))
         # nips ==> ips / (sum of ips over all units)


### PR DESCRIPTION
A super class ```PropensityScoreEstimator```  has been added so as to remove the repetition of functionality and to prevent the recomputation of the propensity score each time. This will significantly improve the performance of the refuters as the covariates in all refuters excluding the placebo refuter will remain the same.