### PR TITLE
add causalml estimator

### DIFF
--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -101,6 +101,7 @@ class Causalml(CausalEstimator):
     def construct_symbolic_estimator(self, estimand):
         expr = "b: " + ",".join(estimand.outcome_variable) + "~"
         # TODO we are conditioning on a postive treatment
+        # TODO create an expression corresponding to each estimator used
         var_list = estimand.treatment_variable + estimand.backdoor_variables
         expr += "+".join(var_list)
         return expr

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -1,0 +1,108 @@
+import inspect
+import numpy as np
+import pandas as pd
+import pdb
+
+from dowhy.causal_estimator import CausalEstimate
+from dowhy.causal_estimator import CausalEstimator
+from importlib import import_module
+import causalml
+
+class Causalml(CausalEstimator):
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        # Add the core method used in the estimator
+        self.identifier_method = self._target_estimand.identifier_method
+        self.logger.debug("The identifier method used {}".format(self.identifier_method))
+
+        # Check the backdoor variables being used
+        self.logger.debug("Back-door variables used:" +
+                          ",".join(self._target_estimand.backdoor_variables))
+        
+        # Add the observed confounders and one hot encode the categorical variables
+        self._observed_common_causes_names = self._target_estimand.backdoor_variables
+        if self._observed_common_causes_names:
+            # Get the data of the unobserved confounders
+            self._observed_common_causes = self._data[self._observed_common_causes_names]
+            # One hot encode the data if they are cateogorical
+            self._observed_common_causes = pd.get_dummies(self._observed_common_causes, drop_first=True)
+        else:
+            self._observed_common_causes = []
+        
+        # Check the instrumental variables involved
+        self.logger.debug("Instrumental variables used:"+
+                        ",".join(self._target_estimand.instrumental_variables))
+        
+        # Perform the same actions as the above
+        self._instrumental_variable_names = self._target_estimand.instrumental_variables
+        if self._instrumental_variable_names:
+            self._instrumental_variables = self._data[self._instrumental_variable_names]
+            self._instrumental_variables = pd.get_dummies(self._instrumental_variables, drop_first=True)
+        else:
+            self._instrumental_variables = []
+
+        #Check if effect modifiers are used
+        self.logger.debug("Effect Modifiers used:" + 
+                        ",".join(self._effect_modifier_names))
+        
+        
+        # Get the class corresponding the the estimator to be used
+        estimator_class = self._get_causalml_class_object(self._causalml_methodname)
+        # Initialize the object
+        # pdb.set_trace()
+        self.estimator = estimator_class(**self.method_params["init_params"])
+        self.logger.info("INFO: Using CausalML Estimator")
+        self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
+        self.logger.info(self.symbolic_estimator)
+        
+    def _get_causalml_class_object(self, module_method_name, *args, **kwargs):
+        
+        try:
+            (module_name, _, class_name) = module_method_name.rpartition(".")
+            estimator_module = import_module(module_name)
+            estimator_class = getattr(estimator_module, class_name)
+
+        except (AttributeError, AssertionError, ImportError):
+            raise ImportError('Error loading {}.{}. Double-check the method name and ensure that all econml dependencies are installed.'.format(module_name, class_name))
+        return estimator_class
+
+    def _estimate_effect(self):
+        X_names = self._instrumental_variable_names + \
+                self._observed_common_causes_names + \
+                self._effect_modifier_names
+
+        y_name = self._outcome_name # We need to make sure that both are pd.Series, so we take the first element
+        treatment_name = self._treatment_name[0] # As we have only one treatment variable
+        
+        func_args={
+            'X':self._data[X_names],
+            'y':self._data[y_name],
+            'treatment':self._data[treatment_name]
+        }
+
+        arg_names = inspect.getfullargspec(self.estimator.estimate_ate)[0]
+        # pdb.set_trace()
+        matched_args = {
+            arg: func_args[arg] for arg in func_args.keys() if arg in arg_names 
+        }
+        value_tuple = self.estimator.estimate_ate(**matched_args) 
+
+        estimate = CausalEstimate(estimate=value_tuple[0],
+                                  target_estimand=self._target_estimand,
+                                  realized_estimand_expr=self.symbolic_estimator,
+                                  effect_intervals=(value_tuple[1],value_tuple[2]),
+                                  _estimator_object=self.estimator)
+
+        return estimate
+        
+
+    def construct_symbolic_estimator(self, estimand):
+        expr = "b: " + ",".join(estimand.outcome_variable) + "~"
+        # TODO we are conditioning on a postive treatment
+        var_list = estimand.treatment_variable + estimand.backdoor_variables
+        expr += "+".join(var_list)
+        return expr
+ 

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -14,7 +14,7 @@ class Causalml(CausalEstimator):
 
         super().__init__(*args, **kwargs)
 
-        # Add the core method used in the estimator
+        # Add the identification method used in the estimator
         self.identifier_method = self._target_estimand.identifier_method
         self.logger.debug("The identifier method used {}".format(self.identifier_method))
 

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -83,7 +83,6 @@ class Causalml(CausalEstimator):
         }
 
         arg_names = inspect.getfullargspec(self.estimator.estimate_ate)[0]
-        # pdb.set_trace()
         matched_args = {
             arg: func_args[arg] for arg in func_args.keys() if arg in arg_names 
         }

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -67,8 +67,7 @@ class Causalml(CausalEstimator):
         return estimator_class
 
     def _estimate_effect(self):
-        X_names = self._instrumental_variable_names + \
-                self._observed_common_causes_names + \
+        X_names = self._observed_common_causes_names + \
                 self._effect_modifier_names
         
         # Both the outcome and the treatment have to be 1D arrays according to the CausalML API

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -70,9 +70,11 @@ class Causalml(CausalEstimator):
         X_names = self._instrumental_variable_names + \
                 self._observed_common_causes_names + \
                 self._effect_modifier_names
-
-        y_name = self._outcome_name # We need to make sure that both are pd.Series, so we take the first element
+        
+        # Both the outcome and the treatment have to be 1D arrays according to the CausalML API
+        y_name = self._outcome_name 
         treatment_name = self._treatment_name[0] # As we have only one treatment variable
+        # We want to pass 'v0' rather than ['v0'] to prevent a shape mismatch
         
         func_args={
             'X':self._data[X_names],

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -25,7 +25,7 @@ class Causalml(CausalEstimator):
         if self._observed_common_causes_names:
             # Get the data of the unobserved confounders
             self._observed_common_causes = self._data[self._observed_common_causes_names]
-            # One hot encode the data if they are cateogorical
+            # One hot encode the data if they are categorical
             self._observed_common_causes = pd.get_dummies(self._observed_common_causes, drop_first=True)
         else:
             self._observed_common_causes = []
@@ -50,7 +50,6 @@ class Causalml(CausalEstimator):
         # Get the class corresponding the the estimator to be used
         estimator_class = self._get_causalml_class_object(self._causalml_methodname)
         # Initialize the object
-        # pdb.set_trace()
         self.estimator = estimator_class(**self.method_params["init_params"])
         self.logger.info("INFO: Using CausalML Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -42,7 +42,7 @@ class Causalml(CausalEstimator):
         else:
             self._instrumental_variables = []
 
-        #Check if effect modifiers are used
+        # Check if effect modifiers are used
         self.logger.debug("Effect Modifiers used:" + 
                         ",".join(self._effect_modifier_names))
         

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -2,8 +2,7 @@ import inspect
 import numpy as np
 import pandas as pd
 
-from dowhy.causal_estimator import CausalEstimate
-from dowhy.causal_estimator import CausalEstimator
+from dowhy.causal_estimator import CausalEstimate, CausalEstimator
 from importlib import import_module
 import causalml
 

--- a/dowhy/causal_estimators/causalml.py
+++ b/dowhy/causal_estimators/causalml.py
@@ -1,7 +1,6 @@
 import inspect
 import numpy as np
 import pandas as pd
-import pdb
 
 from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimator import CausalEstimator

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -19,12 +19,12 @@ except ImportError:
     except subprocess.CalledProcessError:
         installed_failed = True
 
+@pytest.mark.skipif(installed_failed, reason="CausalML was not installed successfully")
 class TestCausalMLEstimator:
     '''
         To test the basic functionality of the CauslML estimators
     '''
     
-    @pytest.mark.skipif(installed_failed)
     def test_LRSRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -60,7 +60,6 @@ class TestCausalMLEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
-    @pytest.mark.skipif(installed_failed)
     def test_XGBTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -96,7 +95,6 @@ class TestCausalMLEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
-    @pytest.mark.skipif(installed_failed)
     def test_MLPTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -137,7 +135,6 @@ class TestCausalMLEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
-    @pytest.mark.skipif(installed_failed)
     def test_XLearner(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -176,7 +173,6 @@ class TestCausalMLEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
-    @pytest.mark.skipif(installed_failed)
     def test_RLearner(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -42,7 +42,7 @@ class TestCausalmlEstimator:
         To test the basic functionality of the CausalML estimators
     '''
     
-    def test_cuasalml_LRSRegressor(self, init_data):
+    def test_causalml_LRSRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -69,7 +69,7 @@ class TestCausalmlEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
-    def test_cuasalml_XGBTRegressor(self, init_data):
+    def test_causalml_XGBTRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -96,7 +96,7 @@ class TestCausalmlEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
-    def test_cuasalml_MLPTRegressor(self, init_data):
+    def test_causalml_MLPTRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -128,7 +128,7 @@ class TestCausalmlEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
-    def test_cuasalml_XLearner(self, init_data):
+    def test_causalml_XLearner(self, init_data):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -158,7 +158,7 @@ class TestCausalmlEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
-    def test_cuasalml_RLearner(self, init_data):
+    def test_causalml_RLearner(self, init_data):
         # Defined a linear dataset with a given set of properties
         data = init_data
 

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -1,0 +1,196 @@
+import pytest
+
+from dowhy import CausalModel
+from dowhy.datasets import linear_dataset
+from xgboost import XGBRegressor
+
+class TestCausalMLEstimator:
+    '''
+        To test the basic functionality of the CauslML estimators
+    '''
+
+    def test_LRSRegressor(self):
+        # Defined a linear dataset with a given set of properties
+        data = linear_dataset(
+            beta=10,
+            num_common_causes=4,
+            num_instruments=2,
+            num_effect_modifiers=2,
+            num_treatments=1,
+            num_samples=1000,
+            treatment_is_binary=True
+        )
+
+        # Create a model that captures the same
+        model = CausalModel(
+            data=data['df'],
+            treatment=data['treatment_name'],
+            outcome=data['outcome_name'],
+            effect_modifiers=data['effect_modifier_names'],
+            graph=data['gml_graph']
+        )
+
+        # Identify the effects within the model
+        identified_estimand = model.identify_effect(
+            proceed_when_unidentifiable=True
+        )
+
+        lr_estimate = model.estimate_effect(
+            identified_estimand,
+            method_name="backdoor.causalml.inference.meta.LRSRegressor",
+            method_params={"init_params":{}}
+        )
+
+        print("The LR estimate obtained:")
+        print(lr_estimate)
+
+    def test_XGBTRegressor(self):
+        # Defined a linear dataset with a given set of properties
+        data = linear_dataset(
+            beta=10,
+            num_common_causes=4,
+            num_instruments=2,
+            num_effect_modifiers=2,
+            num_treatments=1,
+            num_samples=1000,
+            treatment_is_binary=True
+        )
+
+        # Create a model that captures the same
+        model = CausalModel(
+            data=data['df'],
+            treatment=data['treatment_name'],
+            outcome=data['outcome_name'],
+            effect_modifiers=data['effect_modifier_names'],
+            graph=data['gml_graph']
+        )
+
+        # Identify the effects within the model
+        identified_estimand = model.identify_effect(
+            proceed_when_unidentifiable=True
+        )
+
+        xgbt_estimate = model.estimate_effect(
+            identified_estimand,
+            method_name="backdoor.causalml.inference.meta.XGBTRegressor",
+            method_params={"init_params":{}}
+        )
+
+        print("The XGBT estimate obtained:")
+        print(xgbt_estimate)
+
+    def test_MLPTRegressor(self):
+        # Defined a linear dataset with a given set of properties
+        data = linear_dataset(
+            beta=10,
+            num_common_causes=4,
+            num_instruments=2,
+            num_effect_modifiers=2,
+            num_treatments=1,
+            num_samples=1000,
+            treatment_is_binary=True
+        )
+
+        # Create a model that captures the same
+        model = CausalModel(
+            data=data['df'],
+            treatment=data['treatment_name'],
+            outcome=data['outcome_name'],
+            effect_modifiers=data['effect_modifier_names'],
+            graph=data['gml_graph']
+        )
+
+        # Identify the effects within the model
+        identified_estimand = model.identify_effect(
+            proceed_when_unidentifiable=True
+        )
+
+        mlpt_estimate = model.estimate_effect(
+            identified_estimand,
+            method_name="backdoor.causalml.inference.meta.MLPTRegressor",
+            method_params={"init_params":{
+                    'hidden_layer_sizes':(10,10),
+                    'learning_rate_init':0.1,
+                    'early_stopping':True 
+                }
+            }
+        )
+
+        print("The MLPT estimate obtained:")
+        print(mlpt_estimate)
+
+    def test_XLearner(self):
+        # Defined a linear dataset with a given set of properties
+        data = linear_dataset(
+            beta=10,
+            num_common_causes=4,
+            num_instruments=2,
+            num_effect_modifiers=2,
+            num_treatments=1,
+            num_samples=1000,
+            treatment_is_binary=True
+        )
+
+        # Create a model that captures the same
+        model = CausalModel(
+            data=data['df'],
+            treatment=data['treatment_name'],
+            outcome=data['outcome_name'],
+            effect_modifiers=data['effect_modifier_names'],
+            graph=data['gml_graph']
+        )
+
+        # Identify the effects within the model
+        identified_estimand = model.identify_effect(
+            proceed_when_unidentifiable=True
+        )
+
+        xl_estimate = model.estimate_effect(
+            identified_estimand,
+            method_name="backdoor.causalml.inference.meta.BaseXRegressor",
+            method_params={"init_params":{
+                    'learner':XGBRegressor()
+                }
+            }
+        )
+
+        print("The X Learner estimate obtained:")
+        print(xl_estimate)
+
+    def test_RLearner(self):
+        # Defined a linear dataset with a given set of properties
+        data = linear_dataset(
+            beta=10,
+            num_common_causes=4,
+            num_instruments=2,
+            num_effect_modifiers=2,
+            num_treatments=1,
+            num_samples=1000,
+            treatment_is_binary=True
+        )
+
+        # Create a model that captures the same
+        model = CausalModel(
+            data=data['df'],
+            treatment=data['treatment_name'],
+            outcome=data['outcome_name'],
+            effect_modifiers=data['effect_modifier_names'],
+            graph=data['gml_graph']
+        )
+
+        # Identify the effects within the model
+        identified_estimand = model.identify_effect(
+            proceed_when_unidentifiable=True
+        )
+
+        rl_estimate = model.estimate_effect(
+            identified_estimand,
+            method_name="backdoor.causalml.inference.meta.BaseRRegressor",
+            method_params={"init_params":{
+                    'learner':XGBRegressor()
+                }
+            }
+        )
+
+        print("The R Learner estimate obtained:")
+        print(rl_estimate)

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -6,7 +6,7 @@ from dowhy import CausalModel
 from dowhy.datasets import linear_dataset
 
 # To skip the tests if we cannot install causalml
-installed_failed = False
+is_causalml_installed = True
 # Hack to install causalml if not already present
 try:
     __import__("causalml")
@@ -17,7 +17,7 @@ except ImportError:
         # We import this later as we obtained this from causalml
         from xgboost import XGBRegressor
     except subprocess.CalledProcessError:
-        installed_failed = True
+        is_causalml_installed = False
 
 @pytest.fixture
 def init_data():
@@ -33,7 +33,7 @@ def init_data():
     
     return data
 
-@pytest.mark.skipif(installed_failed, reason="CausalML was not installed successfully")
+@pytest.mark.skipif(is_causalml_installed is False, reason="CausalML is not installed")
 class TestCausalmlEstimator:
     '''
         To test the basic functionality of the CausalML estimators

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -42,7 +42,7 @@ class TestCausalmlEstimator:
     
     def test_cuasalml_LRSRegressor(self):
         # Defined a linear dataset with a given set of properties
-        data = init_data
+        data = init_data()
 
         # Create a model that captures the same
         model = CausalModel(
@@ -69,7 +69,7 @@ class TestCausalmlEstimator:
 
     def test_cuasalml_XGBTRegressor(self):
         # Defined a linear dataset with a given set of properties
-        data = init_data
+        data = init_data()
 
         # Create a model that captures the same
         model = CausalModel(
@@ -96,7 +96,7 @@ class TestCausalmlEstimator:
 
     def test_cuasalml_MLPTRegressor(self):
         # Defined a linear dataset with a given set of properties
-        data = init_data
+        data = init_data()
 
         # Create a model that captures the same
         model = CausalModel(
@@ -128,7 +128,7 @@ class TestCausalmlEstimator:
 
     def test_cuasalml_XLearner(self):
         # Defined a linear dataset with a given set of properties
-        data = init_data
+        data = init_data()
 
         # Create a model that captures the same
         model = CausalModel(
@@ -158,7 +158,7 @@ class TestCausalmlEstimator:
 
     def test_cuasalml_RLearner(self):
         # Defined a linear dataset with a given set of properties
-        data = init_data
+        data = init_data()
 
         # Create a model that captures the same
         model = CausalModel(

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -5,21 +5,26 @@ import sys
 from dowhy import CausalModel
 from dowhy.datasets import linear_dataset
 
+# To skip the tests if we cannot install causalml
+installed_failed = False
 # Hack to install causalml if not already present
 try:
     __import__("causalml")
 except ImportError:
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "causalml"])
-finally:
-    __import__("causalml")
-# We import this later as we obtained this from causalml
-from xgboost import XGBRegressor
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "causalml"])
+        __import__("causalml")
+        # We import this later as we obtained this from causalml
+        from xgboost import XGBRegressor
+    except subprocess.CalledProcessError:
+        installed_failed = True
 
 class TestCausalMLEstimator:
     '''
         To test the basic functionality of the CauslML estimators
     '''
-
+    
+    @pytest.mark.skipif(installed_failed)
     def test_LRSRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -55,6 +60,7 @@ class TestCausalMLEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
+    @pytest.mark.skipif(installed_failed)
     def test_XGBTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -90,6 +96,7 @@ class TestCausalMLEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
+    @pytest.mark.skipif(installed_failed)
     def test_MLPTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -130,6 +137,7 @@ class TestCausalMLEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
+    @pytest.mark.skipif(installed_failed)
     def test_XLearner(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(
@@ -168,6 +176,7 @@ class TestCausalMLEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
+    @pytest.mark.skipif(installed_failed)
     def test_RLearner(self):
         # Defined a linear dataset with a given set of properties
         data = linear_dataset(

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -40,7 +40,7 @@ class TestCausalmlEstimator:
         To test the basic functionality of the CausalML estimators
     '''
     
-    def test_LRSRegressor(self):
+    def test_cuasalml_LRSRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -67,7 +67,7 @@ class TestCausalmlEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
-    def test_XGBTRegressor(self):
+    def test_cuasalml_XGBTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -94,7 +94,7 @@ class TestCausalmlEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
-    def test_MLPTRegressor(self):
+    def test_cuasalml_MLPTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -126,7 +126,7 @@ class TestCausalmlEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
-    def test_XLearner(self):
+    def test_cuasalml_XLearner(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -156,7 +156,7 @@ class TestCausalmlEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
-    def test_RLearner(self):
+    def test_cuasalml_RLearner(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -175,7 +175,7 @@ class TestCausalmlEstimator:
         )
 
         rl_estimate = None
-        
+
         try:
             rl_estimate = model.estimate_effect(
                 identified_estimand,

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -1,7 +1,18 @@
 import pytest
+import subprocess
+import sys
 
 from dowhy import CausalModel
 from dowhy.datasets import linear_dataset
+
+# Hack to install causalml if not already present
+try:
+    __import__("causalml")
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "causalml"])
+finally:
+    __import__("causalml")
+# We import this later as we obtained this from causalml
 from xgboost import XGBRegressor
 
 class TestCausalMLEstimator:

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -19,16 +19,9 @@ except ImportError:
     except subprocess.CalledProcessError:
         installed_failed = True
 
-
-@pytest.mark.skipif(installed_failed, reason="CausalML was not installed successfully")
-class TestCausalMLEstimator:
-    '''
-        To test the basic functionality of the CausalML estimators
-    '''
-    
-    def test_LRSRegressor(self):
-        # Defined a linear dataset with a given set of properties
-        data = linear_dataset(
+@pytest.fixture
+def init_data():
+    data = linear_dataset(
             beta=10,
             num_common_causes=4,
             num_instruments=2,
@@ -37,6 +30,18 @@ class TestCausalMLEstimator:
             num_samples=1000,
             treatment_is_binary=True
         )
+    
+    return data
+
+@pytest.mark.skipif(installed_failed, reason="CausalML was not installed successfully")
+class TestCausalMLEstimator:
+    '''
+        To test the basic functionality of the CausalML estimators
+    '''
+    
+    def test_LRSRegressor(self, init_data):
+        # Defined a linear dataset with a given set of properties
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -61,17 +66,9 @@ class TestCausalMLEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
-    def test_XGBTRegressor(self):
+    def test_XGBTRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = linear_dataset(
-            beta=10,
-            num_common_causes=4,
-            num_instruments=2,
-            num_effect_modifiers=2,
-            num_treatments=1,
-            num_samples=1000,
-            treatment_is_binary=True
-        )
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -96,17 +93,9 @@ class TestCausalMLEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
-    def test_MLPTRegressor(self):
+    def test_MLPTRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = linear_dataset(
-            beta=10,
-            num_common_causes=4,
-            num_instruments=2,
-            num_effect_modifiers=2,
-            num_treatments=1,
-            num_samples=1000,
-            treatment_is_binary=True
-        )
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -136,17 +125,9 @@ class TestCausalMLEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
-    def test_XLearner(self):
+    def test_XLearner(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = linear_dataset(
-            beta=10,
-            num_common_causes=4,
-            num_instruments=2,
-            num_effect_modifiers=2,
-            num_treatments=1,
-            num_samples=1000,
-            treatment_is_binary=True
-        )
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -174,17 +155,9 @@ class TestCausalMLEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
-    def test_RLearner(self):
+    def test_RLearner(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = linear_dataset(
-            beta=10,
-            num_common_causes=4,
-            num_instruments=2,
-            num_effect_modifiers=2,
-            num_treatments=1,
-            num_samples=1000,
-            treatment_is_binary=True
-        )
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -34,12 +34,13 @@ def init_data():
     return data
 
 @pytest.mark.skipif(is_causalml_installed is False, reason="CausalML is not installed")
+@pytest.mark.use_fixtures("init_data")
 class TestCausalmlEstimator:
     '''
         To test the basic functionality of the CausalML estimators
     '''
     
-    def test_LRSRegressor(self, init_data):
+    def test_LRSRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -66,7 +67,7 @@ class TestCausalmlEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
-    def test_XGBTRegressor(self, init_data):
+    def test_XGBTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -93,7 +94,7 @@ class TestCausalmlEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
-    def test_MLPTRegressor(self, init_data):
+    def test_MLPTRegressor(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -125,7 +126,7 @@ class TestCausalmlEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
-    def test_XLearner(self, init_data):
+    def test_XLearner(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -155,7 +156,7 @@ class TestCausalmlEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
-    def test_RLearner(self, init_data):
+    def test_RLearner(self):
         # Defined a linear dataset with a given set of properties
         data = init_data
 
@@ -173,14 +174,19 @@ class TestCausalmlEstimator:
             proceed_when_unidentifiable=True
         )
 
-        rl_estimate = model.estimate_effect(
-            identified_estimand,
-            method_name="backdoor.causalml.inference.meta.BaseRRegressor",
-            method_params={"init_params":{
-                    'learner':XGBRegressor()
+        rl_estimate = None
+        
+        try:
+            rl_estimate = model.estimate_effect(
+                identified_estimand,
+                method_name="backdoor.causalml.inference.meta.BaseRRegressor",
+                method_params={"init_params":{
+                        'learner':XGBRegressor()
+                    }
                 }
-            }
-        )
-
+            )
+        except ValueError:
+            print("Error with respect to the number of samples")
+        
         print("The R Learner estimate obtained:")
         print(rl_estimate)

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -14,7 +14,7 @@ except ImportError:
     try:
         subprocess.check_call([sys.executable, "-m", "pip", "install", "causalml"])
         __import__("causalml")
-        # We import this later as we obtained this from causalml
+        # We import XGBRegressor later as we obtained this from causalml
         from xgboost import XGBRegressor
     except subprocess.CalledProcessError:
         is_causalml_installed = False

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -10,6 +10,8 @@ is_causalml_installed = True
 # Hack to install causalml if not already present
 try:
     __import__("causalml")
+    # If it imports successfully the first time
+    from xgboost import XGBRegressor
 except ImportError:
     try:
         subprocess.check_call([sys.executable, "-m", "pip", "install", "causalml"])
@@ -40,9 +42,9 @@ class TestCausalmlEstimator:
         To test the basic functionality of the CausalML estimators
     '''
     
-    def test_cuasalml_LRSRegressor(self):
+    def test_cuasalml_LRSRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = init_data()
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -67,9 +69,9 @@ class TestCausalmlEstimator:
         print("The LR estimate obtained:")
         print(lr_estimate)
 
-    def test_cuasalml_XGBTRegressor(self):
+    def test_cuasalml_XGBTRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = init_data()
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -94,9 +96,9 @@ class TestCausalmlEstimator:
         print("The XGBT estimate obtained:")
         print(xgbt_estimate)
 
-    def test_cuasalml_MLPTRegressor(self):
+    def test_cuasalml_MLPTRegressor(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = init_data()
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -126,9 +128,9 @@ class TestCausalmlEstimator:
         print("The MLPT estimate obtained:")
         print(mlpt_estimate)
 
-    def test_cuasalml_XLearner(self):
+    def test_cuasalml_XLearner(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = init_data()
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(
@@ -156,9 +158,9 @@ class TestCausalmlEstimator:
         print("The X Learner estimate obtained:")
         print(xl_estimate)
 
-    def test_cuasalml_RLearner(self):
+    def test_cuasalml_RLearner(self, init_data):
         # Defined a linear dataset with a given set of properties
-        data = init_data()
+        data = init_data
 
         # Create a model that captures the same
         model = CausalModel(

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -34,7 +34,7 @@ def init_data():
     return data
 
 @pytest.mark.skipif(installed_failed, reason="CausalML was not installed successfully")
-class TestCausalMLEstimator:
+class TestCausalmlEstimator:
     '''
         To test the basic functionality of the CausalML estimators
     '''

--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -19,10 +19,11 @@ except ImportError:
     except subprocess.CalledProcessError:
         installed_failed = True
 
+
 @pytest.mark.skipif(installed_failed, reason="CausalML was not installed successfully")
 class TestCausalMLEstimator:
     '''
-        To test the basic functionality of the CauslML estimators
+        To test the basic functionality of the CausalML estimators
     '''
     
     def test_LRSRegressor(self):


### PR DESCRIPTION
Add 3rd party estimator from uber/causal ml by writing a wrapper in dowhy. This inherits the causal estimator class and currently runs only the Average Treatment Effect estimates.