### PR TITLE
increase tolerence and reduce sample size to speed up tests

### DIFF
--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -183,17 +183,17 @@ class TestRefuter(object):
                 res = True if (error <  self._error_tolerance) else False
                 assert res
  
-    def binary_treatment_testsuite(self, num_common_causes=1,tests_to_run="all"):
-        self.null_refutation_test(num_common_causes=num_common_causes)
+    def binary_treatment_testsuite(self, num_samples=100000,num_common_causes=1,tests_to_run="all"):
+        self.null_refutation_test(num_common_causes=num_common_causes,num_samples=num_samples)
         if tests_to_run != "atleast-one-common-cause":
-            self.null_refutation_test(num_common_causes=0)
+            self.null_refutation_test(num_common_causes=0,num_samples=num_samples)
 
-    def continuous_treatment_testsuite(self, num_common_causes=1,tests_to_run="all"):
+    def continuous_treatment_testsuite(self, num_samples=100000,num_common_causes=1,tests_to_run="all"):
         self.null_refutation_test(
-            num_common_causes=num_common_causes,
+            num_common_causes=num_common_causes,num_samples=num_samples,
             treatment_is_binary=False)
         if tests_to_run != "atleast-one-common-cause":
-            self.null_refutation_test(num_common_causes=0,
+            self.null_refutation_test(num_common_causes=0, num_samples=num_samples,
                     treatment_is_binary=False)
     
         

--- a/tests/causal_refuters/test_bootstrap_refuter.py
+++ b/tests/causal_refuters/test_bootstrap_refuter.py
@@ -10,72 +10,72 @@ class TestDataSubsetRefuter(object):
 
     '''
 
-    @pytest.mark.parametrize(["error_tolerance","estimator_method"],
-                              [(0.05, "iv.instrumental_variable")])
-    def test_refutation_bootstrap_refuter_continuous(self, error_tolerance, estimator_method):
+    @pytest.mark.parametrize(["error_tolerance","estimator_method","num_samples"],
+                              [(0.05, "iv.instrumental_variable",1000)])
+    def test_refutation_bootstrap_refuter_continuous(self, error_tolerance, estimator_method, num_samples):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "bootstrap_refuter")
-        refuter_tester.continuous_treatment_testsuite() # Run both
+        refuter_tester.continuous_treatment_testsuite(num_samples=num_samples) # Run both
 
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-                             [(0.05, "backdoor.propensity_score_matching")])
-    def test_refutation_bootstrap_refuter_binary(self, error_tolerance, estimator_method):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method","num_samples"],
+                             [(0.05, "backdoor.propensity_score_matching",1000)])
+    def test_refutation_bootstrap_refuter_binary(self, error_tolerance, estimator_method, num_samples):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "bootstrap_refuter")
-        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause")
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     
-    @pytest.mark.parametrize(["error_tolerance","estimator_method","num_common_causes","required_variables"],
-                              [(0.05, "iv.instrumental_variable",5, 3)])
-    def test_refutation_bootstrap_refuter_continuous_integer_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables):
+    @pytest.mark.parametrize(["error_tolerance","estimator_method","num_common_causes","required_variables", "num_samples"],
+                              [(0.05, "iv.instrumental_variable",5, 3, 1000)])
+    def test_refutation_bootstrap_refuter_continuous_integer_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples):
         refuter_tester = TestRefuter(error_tolerance, 
                                      estimator_method, 
                                      "bootstrap_refuter",
                                      required_variables=required_variables,
                                      )
-        refuter_tester.continuous_treatment_testsuite(num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause") # Run atleast one common cause
+        refuter_tester.continuous_treatment_testsuite(num_samples=num_samples,num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause") # Run atleast one common cause
 
-    @pytest.mark.parametrize(["error_tolerance","estimator_method", "num_common_causes", "required_variables"],
-                              [(0.05, "iv.instrumental_variable", 5, ["W0","W1"])])
-    def test_refutation_bootstrap_refuter_continuous_list_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables):
+    @pytest.mark.parametrize(["error_tolerance","estimator_method", "num_common_causes", "required_variables", "num_samples"],
+                              [(0.05, "iv.instrumental_variable", 5, ["W0","W1"], 1000)])
+    def test_refutation_bootstrap_refuter_continuous_list_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples):
         refuter_tester = TestRefuter(error_tolerance,
                                      estimator_method,
                                      "bootstrap_refuter",
                                      required_variables=required_variables)
-        refuter_tester.continuous_treatment_testsuite(num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause") # Run atleast one common cause
+        refuter_tester.continuous_treatment_testsuite(num_samples=num_samples,num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause") # Run atleast one common cause
 
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_common_causes", "required_variables"],
-                             [(0.05, "backdoor.propensity_score_matching", 5, 3)])
-    def test_refutation_bootstrap_refuter_binary_integer_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_common_causes", "required_variables", "num_samples"],
+                             [(0.1, "backdoor.propensity_score_matching", 5, 3, 5000)])
+    def test_refutation_bootstrap_refuter_binary_integer_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples):
         refuter_tester = TestRefuter(error_tolerance, 
                                      estimator_method,
                                     "bootstrap_refuter",
                                     required_variables=required_variables)
-        refuter_tester.binary_treatment_testsuite(num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause")
+        refuter_tester.binary_treatment_testsuite(num_samples=num_samples,num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause")
     
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_common_causes", "required_variables"],
-                             [(0.05, "backdoor.propensity_score_matching",5, ["W0", "W1"])])
-    def test_refutation_bootstrap_refuter_binary_list_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_common_causes", "required_variables", "num_samples"],
+                             [(0.1, "backdoor.propensity_score_matching",5, ["W0", "W1"], 5000)])
+    def test_refutation_bootstrap_refuter_binary_list_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples):
         refuter_tester = TestRefuter(error_tolerance,
                                      estimator_method, 
                                      "bootstrap_refuter",
                                      required_variables=required_variables)
-        refuter_tester.binary_treatment_testsuite(num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause")
+        refuter_tester.binary_treatment_testsuite(num_samples=num_samples,num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause")
 
-    @pytest.mark.parametrize(["error_tolerance","estimator_method", "num_common_causes", "required_variables"],
-                              [(0.05, "iv.instrumental_variable", 5, ["-W0","-W1"])])
-    def test_refutation_bootstrap_refuter_continuous_list_negative_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables):
+    @pytest.mark.parametrize(["error_tolerance","estimator_method", "num_common_causes", "required_variables", "num_samples"],
+                              [(0.1, "iv.instrumental_variable", 5, ["-W0","-W1"], 5000)])
+    def test_refutation_bootstrap_refuter_continuous_list_negative_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples):
         refuter_tester = TestRefuter(error_tolerance,
                                      estimator_method,
                                      "bootstrap_refuter",
                                      required_variables=required_variables)
-        refuter_tester.continuous_treatment_testsuite(num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause") # Run atleast one common cause
+        refuter_tester.continuous_treatment_testsuite(num_samples=num_samples,num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause") # Run atleast one common cause
 
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_common_causes", "required_variables"],
-                             [(0.05, "backdoor.propensity_score_matching",5, ["-W0", "-W1"])])
-    def test_refutation_bootstrap_refuter_binary_list_negative_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_common_causes", "required_variables", "num_samples"],
+                             [(0.1, "backdoor.propensity_score_matching",5, ["-W0", "-W1"], 5000)])
+    def test_refutation_bootstrap_refuter_binary_list_negative_argument(self, error_tolerance, estimator_method, num_common_causes, required_variables, num_samples):
         refuter_tester = TestRefuter(error_tolerance,
                                      estimator_method, 
                                      "bootstrap_refuter",
                                      required_variables=required_variables)
-        refuter_tester.binary_treatment_testsuite(num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause")
+        refuter_tester.binary_treatment_testsuite(num_samples=num_samples,num_common_causes=num_common_causes, tests_to_run="atleast-one-common-cause")
     
     


### PR DESCRIPTION
Reduce the time taken by the bootstrap refuter, as it takes a major portion of the testing time.