### PR TITLE
Use pytest.importor to account for CausalMl dependency

### DIFF
--- a/tests/causal_estimators/test_causalml_estimator.py
+++ b/tests/causal_estimators/test_causalml_estimator.py
@@ -5,21 +5,9 @@ import sys
 from dowhy import CausalModel
 from dowhy.datasets import linear_dataset
 
-# To skip the tests if we cannot install causalml
-is_causalml_installed = True
-# Hack to install causalml if not already present
-try:
-    __import__("causalml")
-    # If it imports successfully the first time
-    from xgboost import XGBRegressor
-except ImportError:
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "causalml"])
-        __import__("causalml")
-        # We import XGBRegressor later as we obtained this from causalml
-        from xgboost import XGBRegressor
-    except subprocess.CalledProcessError:
-        is_causalml_installed = False
+causalml = pytest.importorskip("causalml")
+from xgboost import XGBRegressor
+
 
 @pytest.fixture
 def init_data():
@@ -35,7 +23,6 @@ def init_data():
     
     return data
 
-@pytest.mark.skipif(is_causalml_installed is False, reason="CausalML is not installed")
 @pytest.mark.use_fixtures("init_data")
 class TestCausalmlEstimator:
     '''

--- a/tests/causal_refuters/test_add_unobserved_common_cause.py
+++ b/tests/causal_refuters/test_add_unobserved_common_cause.py
@@ -42,7 +42,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
                 effect_strength_on_t = effect_strength_on_t,
                 effect_strength_on_y = effect_strength_on_y)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
-        mock_fig.assert_called()  # we patched figure plotting call to avoid drawing plots during tests
+        assert mock_fig.call_count > 0  # we patched figure plotting call to avoid drawing plots during tests
 
     @pytest.mark.parametrize(["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
                              [(0.01, "iv.instrumental_variable", np.arange(0.01, 0.02, 0.001), 0.02),])
@@ -56,7 +56,7 @@ class TestAddUnobservedCommonCauseRefuter(object):
                 effect_strength_on_t = effect_strength_on_t,
                 effect_strength_on_y = effect_strength_on_y)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
-        mock_fig.assert_called()  # we patched figure plotting call to avoid drawing plots during tests
+        assert mock_fig.call_count > 0  # we patched figure plotting call to avoid drawing plots during tests
 
     @pytest.mark.parametrize(["error_tolerance", "estimator_method", "effect_strength_on_t", "effect_strength_on_y"],
                              [(0.01, "iv.instrumental_variable", 0.01, np.arange(0.02, 0.03, 0.001)),])
@@ -70,5 +70,5 @@ class TestAddUnobservedCommonCauseRefuter(object):
                 effect_strength_on_t = effect_strength_on_t,
                 effect_strength_on_y = effect_strength_on_y)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
-        mock_fig.assert_called()  # we patched figure plotting call to avoid drawing plots during tests
+        assert mock_fig.call_count > 0  # we patched figure plotting call to avoid drawing plots during tests
 


### PR DESCRIPTION
We replace the download hack by using pytest.importor to check if CausalML is present.