### PR TITLE
Refactor causal_estimator to include standard error and allow repeated calls for CI, std error and test significance

### DIFF
--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -43,12 +43,12 @@ class CausalEstimator:
         :param outcome: name of the outcome variable
         :param control_value: Value of the treatment in the control group, for effect estimation.  If treatment is multi-variate, this can be a list.
         :param treatment_value: Value of the treatment in the treated group, for effect estimation. If treatment is multi-variate, this can be a list.
-        :param test_significance: Method for testing statistical significance. If testing is not required, its value is False (default). All DoWhy estimators support "bootstrap" as the method name. Each estimator can implement its own specific statistical significance methods.
+        :param test_significance: Binary flag or a string indicating whether to test significance and by which method. All estimators support test_significance="bootstrap" that estimates a p-value for the obtained estimate using the bootstrap method. Individual estimators can override this to support custom testing methods. The bootstrap method supports an optional parameter, num_null_simulations that can be specified through the params dictionary. If False, no testing is done. If True, significance of the estimate is tested using the custom method if available, otherwise by bootstrap. 
         :param evaluate_effect_strength: (Experimental) whether to evaluate the strength of effect
-        :param confidence_intervals: Method name for computing confidence intervals. If intervals are not required, its value is False (default).
-        :param target_units: (Experimental) The units for which the treatment effect should be estimated. This can be a string for common specifications of target units (namely, "ate", "att" and "atc"). It can also be a lambda function that can be used as an index for the data (pandas DataFrame). Alternatively, it can be a new DataFrame that contains values of the effect_modifiers and effect will be estimated only for this new data.
-        :param effect_modifiers: variables on which to compute separate effects, or return a heterogeneous effect function. Not all methods support this currently.
-        :param params: (optional) additional method parameters
+        :param confidence_intervals: Binary flag or a string indicating whether the confidence intervals should be computed and which method should be used. All methods support estimation of confidence intervals using the bootstrap method by using the parameter confidence_intervals="bootstrap". The bootstrap method takes in two arguments (num_ci_simulations and sample_size_fraction) that can be optionally specified in the params dictionary. Estimators may also override this to implement their own confidence interval method. If this parameter is False, no confidence intervals are computed. If True, confidence intervals are computed by the estimator's specific method if available, otherwise through bootstrap.
+        :param target_units: The units for which the treatment effect should be estimated. This can be a string for common specifications of target units (namely, "ate", "att" and "atc"). It can also be a lambda function that can be used as an index for the data (pandas DataFrame). Alternatively, it can be a new DataFrame that contains values of the effect_modifiers and effect will be estimated only for this new data.
+        :param effect_modifiers: Variables on which to compute separate effects, or return a heterogeneous effect function. Not all methods support this currently.
+        :param params: (optional) Additional method parameters
             num_null_simulations: The number of simulations for testing the statistical significance of the estimator
             num_ci_simulations: The number of simulations for finding the confidence interval (and/or standard error) for a estimate
             sample_size_fraction: The size of the sample for the bootstrap estimator
@@ -245,7 +245,7 @@ class CausalEstimator:
             Method to compute confidence interval using bootstrapped sampling.
             
             :param confidence_level: The level for which to compute CI (e.g., 95% confidence level translates to confidence_level=0.95)
-            :param num_simulations: The number of simulations to be performed to get the bootstrap confidence intervals.
+            :param num_ci_simulations: The number of simulations to be performed to get the bootstrap confidence intervals.
             :param sample_size_fraction: The fraction of the dataset to be resampled.
             :returns: confidence interval at the specified level.
 
@@ -329,9 +329,11 @@ class CausalEstimator:
         
     def _estimate_std_error_with_bootstrap(self, num_ci_simulations=None,
             sample_size_fraction=None):
-        """ Compute standard error using the bootstrap method.
+        """ Compute standard error using the bootstrap method. Standard error
+        and confidence intervals use the same parameter num_ci_simulations for
+        the number of bootstrap simulations.
 
-        :param num_simulations: Number of bootstrapped samples.
+        :param num_ci_simulations: Number of bootstrapped samples.
         :param sample_size_fraction: Fraction of data to be resampled. 
         :returns: Standard error of the obtained estimate.
         """

--- a/dowhy/causal_estimator.py
+++ b/dowhy/causal_estimator.py
@@ -45,12 +45,12 @@ class CausalEstimator:
         :param treatment_value: Value of the treatment in the treated group, for effect estimation. If treatment is multi-variate, this can be a list.
         :param test_significance: Binary flag or a string indicating whether to test significance and by which method. All estimators support test_significance="bootstrap" that estimates a p-value for the obtained estimate using the bootstrap method. Individual estimators can override this to support custom testing methods. The bootstrap method supports an optional parameter, num_null_simulations that can be specified through the params dictionary. If False, no testing is done. If True, significance of the estimate is tested using the custom method if available, otherwise by bootstrap. 
         :param evaluate_effect_strength: (Experimental) whether to evaluate the strength of effect
-        :param confidence_intervals: Binary flag or a string indicating whether the confidence intervals should be computed and which method should be used. All methods support estimation of confidence intervals using the bootstrap method by using the parameter confidence_intervals="bootstrap". The bootstrap method takes in two arguments (num_ci_simulations and sample_size_fraction) that can be optionally specified in the params dictionary. Estimators may also override this to implement their own confidence interval method. If this parameter is False, no confidence intervals are computed. If True, confidence intervals are computed by the estimator's specific method if available, otherwise through bootstrap.
+        :param confidence_intervals: Binary flag or a string indicating whether the confidence intervals should be computed and which method should be used. All methods support estimation of confidence intervals using the bootstrap method by using the parameter confidence_intervals="bootstrap". The bootstrap method takes in two arguments (num_simulations and sample_size_fraction) that can be optionally specified in the params dictionary. Estimators may also override this to implement their own confidence interval method. If this parameter is False, no confidence intervals are computed. If True, confidence intervals are computed by the estimator's specific method if available, otherwise through bootstrap.
         :param target_units: The units for which the treatment effect should be estimated. This can be a string for common specifications of target units (namely, "ate", "att" and "atc"). It can also be a lambda function that can be used as an index for the data (pandas DataFrame). Alternatively, it can be a new DataFrame that contains values of the effect_modifiers and effect will be estimated only for this new data.
         :param effect_modifiers: Variables on which to compute separate effects, or return a heterogeneous effect function. Not all methods support this currently.
         :param params: (optional) Additional method parameters
             num_null_simulations: The number of simulations for testing the statistical significance of the estimator
-            num_ci_simulations: The number of simulations for finding the confidence interval (and/or standard error) for a estimate
+            num_simulations: The number of simulations for finding the confidence interval (and/or standard error) for a estimate
             sample_size_fraction: The size of the sample for the bootstrap estimator
             confidence_level: The confidence level of the confidence interval estimate
         :returns: an instance of the estimator class.
@@ -84,8 +84,8 @@ class CausalEstimator:
         if not hasattr(self, 'num_null_simulations'):
             self.num_null_simulations = CausalEstimator.DEFAULT_NUMBER_OF_SIMULATIONS_STAT_TEST
 
-        if not hasattr(self, 'num_ci_simulations'):
-            self.num_ci_simulations = CausalEstimator.DEFAULT_NUMBER_OF_SIMULATIONS_CI
+        if not hasattr(self, 'num_simulations'):
+            self.num_simulations = CausalEstimator.DEFAULT_NUMBER_OF_SIMULATIONS_CI
 
         if not hasattr(self, 'sample_size_fraction'):
             self.sample_size_fraction = CausalEstimator.DEFAULT_SAMPLE_SIZE_FRACTION
@@ -233,19 +233,19 @@ class CausalEstimator:
             simulation_results[index] = new_effect.value
         
         estimates = CausalEstimator.BootstrapEstimates(simulation_results,
-                {'num_ci_simulations': num_bootstrap_simulations,
+                {'num_simulations': num_bootstrap_simulations,
                 'sample_size_fraction': sample_size_fraction})
         return estimates
 
 
     def _estimate_confidence_intervals_with_bootstrap(self,
             confidence_level=None,
-            num_ci_simulations=None, sample_size_fraction=None):
+            num_simulations=None, sample_size_fraction=None):
         '''
             Method to compute confidence interval using bootstrapped sampling.
             
             :param confidence_level: The level for which to compute CI (e.g., 95% confidence level translates to confidence_level=0.95)
-            :param num_ci_simulations: The number of simulations to be performed to get the bootstrap confidence intervals.
+            :param num_simulations: The number of simulations to be performed to get the bootstrap confidence intervals.
             :param sample_size_fraction: The fraction of the dataset to be resampled.
             :returns: confidence interval at the specified level.
 
@@ -254,19 +254,19 @@ class CausalEstimator:
             https://projecteuclid.org/download/pdf_1/euclid.ss/1032280214
         '''
         # Using class default parameters if not specified
-        if num_ci_simulations is None:
-            num_ci_simulations = self.num_ci_simulations
+        if num_simulations is None:
+            num_simulations = self.num_simulations
         if sample_size_fraction is None:
             sample_size_fraction = self.sample_size_fraction
 
         # Checking if bootstrap_estimates are already computed
         if self._bootstrap_estimates is None:
             self._bootstrap_estimates = self._generate_bootstrap_estimates(
-                    num_ci_simulations, sample_size_fraction)
+                    num_simulations, sample_size_fraction)
         elif CausalEstimator.is_bootstrap_parameter_changed(self._bootstrap_estimates.params, locals()):
             # Checked if any parameter is changed from the previous std error estimate
             self._bootstrap_estimates = self._generate_bootstrap_estimates(
-                    num_ci_simulations, sample_size_fraction)
+                    num_simulations, sample_size_fraction)
         # Now use the data obtained from the simulations to get the value of the confidence estimates
         # Sort the simulations
         bootstrap_estimates = np.sort(self._bootstrap_estimates.estimates)
@@ -327,29 +327,29 @@ class CausalEstimator:
                         confidence_level, method=method, **kwargs)
         return confidence_intervals
         
-    def _estimate_std_error_with_bootstrap(self, num_ci_simulations=None,
+    def _estimate_std_error_with_bootstrap(self, num_simulations=None,
             sample_size_fraction=None):
         """ Compute standard error using the bootstrap method. Standard error
-        and confidence intervals use the same parameter num_ci_simulations for
+        and confidence intervals use the same parameter num_simulations for
         the number of bootstrap simulations.
 
-        :param num_ci_simulations: Number of bootstrapped samples.
+        :param num_simulations: Number of bootstrapped samples.
         :param sample_size_fraction: Fraction of data to be resampled. 
         :returns: Standard error of the obtained estimate.
         """
         # Use existing params, if new user defined params are not present
-        if num_ci_simulations is None:
-            num_ci_simulations = self.num_ci_simulations
+        if num_simulations is None:
+            num_simulations = self.num_simulations
         if sample_size_fraction is None:
             sample_size_fraction = self.sample_size_fraction
         # Checking if bootstrap_estimates are already computed
         if self._bootstrap_estimates is None:
             self._bootstrap_estimates = self._generate_bootstrap_estimates(
-                    num_ci_simulations, sample_size_fraction)
+                    num_simulations, sample_size_fraction)
         elif CausalEstimator.is_bootstrap_parameter_changed(self._bootstrap_estimates.params, locals()):
             # Check if any parameter is changed from the previous std error estimate
             self._bootstrap_estimates = self._generate_bootstrap_estimates(
-                    num_ci_simulations, sample_size_fraction)
+                    num_simulations, sample_size_fraction)
 
         std_error = np.std(self._bootstrap_estimates.estimates)
         return std_error

--- a/dowhy/causal_estimators/linear_regression_estimator.py
+++ b/dowhy/causal_estimators/linear_regression_estimator.py
@@ -71,6 +71,7 @@ class LinearRegressionEstimator(CausalEstimator):
                 curr_treatment = treatment_2d[:,i]
                 new_features = curr_treatment[:, np.newaxis] * self._effect_modifiers.to_numpy()
                 features = np.concatenate((features, new_features), axis=1)
+        features = features.astype(float, copy=False) # converting to float in case of binary treatment and no other variables
         features = sm.add_constant(features) # to add an intercept term
         return features
 

--- a/dowhy/causal_estimators/linear_regression_estimator.py
+++ b/dowhy/causal_estimators/linear_regression_estimator.py
@@ -1,12 +1,13 @@
 import numpy as np
-from sklearn import linear_model
 import pandas as pd
+import statsmodels.api as sm
+from sklearn import linear_model
 import itertools
 
 from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimator import CausalEstimator
 
-import statsmodels.api as sm
+
 
 class LinearRegressionEstimator(CausalEstimator):
     """Compute effect of treatment using linear regression.
@@ -36,15 +37,16 @@ class LinearRegressionEstimator(CausalEstimator):
 
     def _estimate_effect(self):
         features, self._linear_model = self._build_linear_model()
-        coefficients = self._linear_model.coef_
+        coefficients = self._linear_model.params[1:] # first coefficient is the intercept
         self.logger.debug("Coefficients of the fitted linear model: " +
                           ",".join(map(str, coefficients)))
         # All treatments are set to the same constant value
         effect_estimate = self._do(self._treatment_value) - self._do(self._control_value)
+        intercept_parameter = self._linear_model.params[0]
         estimate = CausalEstimate(estimate=effect_estimate,
                               target_estimand=self._target_estimand,
                               realized_estimand_expr=self.symbolic_estimator,
-                              intercept=self._linear_model.intercept_)
+                              intercept=intercept_parameter)
         return estimate
 
     def construct_symbolic_estimator(self, estimand):
@@ -69,19 +71,33 @@ class LinearRegressionEstimator(CausalEstimator):
                 curr_treatment = treatment_2d[:,i]
                 new_features = curr_treatment[:, np.newaxis] * self._effect_modifiers.to_numpy()
                 features = np.concatenate((features, new_features), axis=1)
+        features = sm.add_constant(features) # to add an intercept term
         return features
 
     def _build_linear_model(self):
         features = self._build_features()
-        model = linear_model.LinearRegression()
-        model.fit(features, self._outcome)
+        model = sm.OLS(self._outcome, features).fit()
         return (features, model)
 
     def _do(self, x):
         if not self._linear_model:
             _, self._linear_model = self._build_linear_model()
+        # Replacing treatment values by given x
         interventional_treatment_2d = np.full((self._treatment.shape[0], len(self._treatment_name)), x)
         features = self._build_features()
-        new_features = np.concatenate((interventional_treatment_2d, features[:,len(self._treatment_name): ]), axis=1)
+        new_features = np.concatenate((features[:,0, np.newaxis], interventional_treatment_2d, features[:,(1+len(self._treatment_name)): ]), axis=1) 
         interventional_outcomes = self._linear_model.predict(new_features)
         return interventional_outcomes.mean()
+
+    def _estimate_confidence_intervals(self, confidence_level,
+            method=None):
+        conf_ints = self._linear_model.conf_int(alpha=1-confidence_level)
+        return conf_ints.to_numpy()[1:(len(self._treatment_name)+1),:]
+
+    def _estimate_std_error(self, method=None):
+        std_error = self._linear_model.bse[1:(len(self._treatment_name)+1)]
+        return std_error.to_numpy()
+
+    def _test_significance(self, estimate_value, method=None):
+        pvalue = self._linear_model.pvalues[1:(len(self._treatment_name)+1)]
+        return {'p_value': pvalue.to_numpy()} 

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -7,7 +7,7 @@ import pdb
 
 from dowhy.causal_refuter import CausalRefutation
 from dowhy.causal_refuter import CausalRefuter
-from dowhy.causal_estimator import CausalEstimator
+from dowhy.causal_estimator import CausalEstimator,CausalEstimate
 
 from sklearn.linear_model import LinearRegression
 from sklearn.neighbors import KNeighborsRegressor
@@ -174,9 +174,10 @@ class DummyOutcomeRefuter(CausalRefuter):
         # Note: We hardcode the estimate value to ZERO as we want to check if it falls in the distribution of the refuter
         # Ideally we should expect that ZERO should fall in the distribution of the effect estimates as we have severed any causal 
         # relationship between the treatment and the outcome.
-        
-        dummy_estimator = copy.deepcopy(self._estimate)
-        dummy_estimator.value = 0
+        dummy_estimator = CausalEstimate(
+                estimate = 0,
+                target_estimand =self._estimate.target_estimand,
+                realized_estimand_expr=self._estimate.realized_estimand_expr)
 
         if no_estimator:
             refute = CausalRefutation(

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -303,8 +303,6 @@ class DummyOutcomeRefuter(CausalRefuter):
         else:
             raise ValueError("Passed {}. Expected bool, float, int or categorical.".format(variable_type.name))
 
-        # return data_chunks
-            
     def _estimate_dummy_outcome(self, action, X_train, outcome, **func_args):
         """
         A function that takes in any sklearn estimator and returns a trained estimator

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -6,7 +6,7 @@ import logging
 
 from dowhy.causal_refuter import CausalRefutation
 from dowhy.causal_refuter import CausalRefuter
-from dowhy.causal_estimator import CausalEstimator
+from dowhy.causal_estimator import CausalEstimator, CausalEstimate
 
 class PlaceboTreatmentRefuter(CausalRefuter):
     """Refute an estimate by replacing treatment with a randomly-generated placebo variable.
@@ -125,9 +125,10 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         # Note: We hardcode the estimate value to ZERO as we want to check if it falls in the distribution of the refuter
         # Ideally we should expect that ZERO should fall in the distribution of the effect estimates as we have severed any causal
         # relationship between the treatment and the outcome.
-
-        dummy_estimator = copy.deepcopy(self._estimate)
-        dummy_estimator.value = 0
+        dummy_estimator = CausalEstimate(
+                estimate = 0,
+                target_estimand =self._estimate.target_estimand,
+                realized_estimand_expr=self._estimate.realized_estimand_expr)
 
         refute.add_significance_test_results(
             self.test_significance(dummy_estimator, sample_estimates)

--- a/tests/causal_estimators/test_linear_regression_estimator.py
+++ b/tests/causal_estimators/test_linear_regression_estimator.py
@@ -21,5 +21,12 @@ class TestLinearRegressionEstimator(object):
                 num_effect_modifiers = num_effect_modifiers,
                 num_treatments=num_treatments,
                 treatment_is_binary=treatment_is_binary,
-                outcome_is_binary=outcome_is_binary
+                outcome_is_binary=outcome_is_binary,
+                confidence_intervals=[True,],
+                test_significance=[True,],
+                method_params={
+                    'num_ci_simulations': 10,
+                    'num_null_simulations': 10
+                    }
                 )
+

--- a/tests/causal_estimators/test_propensity_score_matching_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_matching_estimator.py
@@ -21,5 +21,12 @@ class TestPropensityScoreMatchingEstimator(object):
                 num_effect_modifiers = num_effect_modifiers,
                 num_treatments=num_treatments,
                 treatment_is_binary=treatment_is_binary,
-                outcome_is_binary=outcome_is_binary
+                outcome_is_binary=outcome_is_binary,
+                confidence_intervals=[False,],
+                test_significance=[False,],
+                method_params={
+                    'num_ci_simulations': 10,
+                    'num_null_simulations': 10
+                    }
                 )
+

--- a/tests/causal_estimators/test_propensity_score_stratification_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_stratification_estimator.py
@@ -21,5 +21,11 @@ class TestPropensityScoreStratificationEstimator(object):
                 num_effect_modifiers = num_effect_modifiers,
                 num_treatments=num_treatments,
                 treatment_is_binary=treatment_is_binary,
-                outcome_is_binary=outcome_is_binary
+                outcome_is_binary=outcome_is_binary,
+                confidence_intervals=[True,],
+                test_significance=[True,],
+                method_params={
+                    'num_ci_simulations': 10,
+                    'num_null_simulations': 10
+                    }
                 )

--- a/tests/causal_estimators/test_propensity_score_weighting_estimator.py
+++ b/tests/causal_estimators/test_propensity_score_weighting_estimator.py
@@ -25,5 +25,11 @@ class TestPropensityScoreWeightingEstimator(object):
                 num_effect_modifiers = num_effect_modifiers,
                 num_treatments=num_treatments,
                 treatment_is_binary=treatment_is_binary,
-                outcome_is_binary=outcome_is_binary
+                outcome_is_binary=outcome_is_binary,
+                confidence_intervals=[True,],
+                test_significance=[True,],
+                method_params={
+                    'num_ci_simulations': 10,
+                    'num_null_simulations': 10
+                    }
                 )

--- a/tests/causal_refuters/test_placebo_refuter.py
+++ b/tests/causal_refuters/test_placebo_refuter.py
@@ -4,14 +4,16 @@ from .base import TestRefuter
 
 @pytest.mark.usefixtures("fixed_seed")
 class TestPlaceboRefuter(object):
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-                             [(0.03, "backdoor.linear_regression")])
-    def test_refutation_placebo_refuter_continuous(self, error_tolerance, estimator_method):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_samples"],
+                             [(0.03, "backdoor.linear_regression", 1000)])
+    def test_refutation_placebo_refuter_continuous(self, error_tolerance, 
+            estimator_method, num_samples):
             refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
-            refuter_tester.continuous_treatment_testsuite() # Run both
+            refuter_tester.continuous_treatment_testsuite(num_samples=num_samples) # Run both
 
-    @pytest.mark.parametrize(["error_tolerance", "estimator_method"],
-                              [(0.05, "backdoor.propensity_score_matching")])
-    def test_refutation_placebo_refuter_binary(self, error_tolerance, estimator_method):
+    @pytest.mark.parametrize(["error_tolerance", "estimator_method", "num_samples"],
+                              [(0.1, "backdoor.propensity_score_matching", 5000)])
+    def test_refutation_placebo_refuter_binary(self, error_tolerance, 
+            estimator_method, num_samples):
         refuter_tester = TestRefuter(error_tolerance, estimator_method, "placebo_treatment_refuter")
-        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause")
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)


### PR DESCRIPTION
Major refactor of causal estimator: 
1. estimate now stores a reference to the estimator.
2. once a user has the estimate object, they can call to estimate CI, or std error, or test significance. Previously, they could not and had to call estimate_effect again.
3. Support for estimating standard error of the estimate.