### PR TITLE
Support for when effect modifiers and common causes include common variables and compatibility with econml

### DIFF
--- a/docs/source/example_notebooks/dowhy-conditional-treatment-effects.ipynb
+++ b/docs/source/example_notebooks/dowhy-conditional-treatment-effects.ipynb
@@ -851,7 +851,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/example_notebooks/dowhy_simple_example.ipynb
+++ b/docs/source/example_notebooks/dowhy_simple_example.ipynb
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -47,7 +47,7 @@ class CausalModel:
         :param common_causes: names of common causes of treatment and _outcome. Only used when graph is None.
         :param instruments: names of instrumental variables for the effect of
         treatment on outcome. Only used when graph is None.
-        :param effect_modifiers: names of variables that can modify the treatment effect. If not provided, then the causal graph is used to find the effect modifiers. Estimators will return multiple different estimates based on each value of effect_modifiers. If you are using an EconML estimator, then effect modifiers should be a subset of common causes.
+        :param effect_modifiers: names of variables that can modify the treatment effect. If not provided, then the causal graph is used to find the effect modifiers. Estimators will return multiple different estimates based on each value of effect_modifiers.
         :param estimand_type: the type of estimand requested (currently only "nonparametric-ate" is supported). In the future, may support other specific parametric forms of identification.
         :param proceed_when_unidentifiable: does the identification proceed by ignoring potential unobserved confounders. Binary flag.
         :param missing_nodes_as_confounders: Binary flag indicating whether variables in the dataframe that are not included in the causal graph, should be  automatically included as confounder nodes.


### PR DESCRIPTION
## Minor changes to causal model and graph to support cases when effect modifiers and common causes can overlap
* The key idea is to process such a variable as a common cause but also store its status as a effect modifier
* causal graph input also allows to specify an effect_modifier variable, because the desired variables on which effect needs to be separated out may be different from all effect modifiers 

## Introduce a warning in econml estimator whenever effect modifiers are not a subset of common causes
