### PR TITLE
fixed logging bug for ols results

### DIFF
--- a/dowhy/causal_estimators/linear_regression_estimator.py
+++ b/dowhy/causal_estimators/linear_regression_estimator.py
@@ -44,7 +44,7 @@ class LinearRegressionEstimator(CausalEstimator):
             coefficients = self._linear_model.params[1:] # first coefficient is the intercept
             self.logger.debug("Coefficients of the fitted linear model: " +
                           ",".join(map(str, coefficients)))
-            print(self._linear_model.summary())
+            self.logger.debug(self._linear_model.summary())
         # All treatments are set to the same constant value
         effect_estimate = self._do(self._treatment_value, data_df) - self._do(self._control_value, data_df)
         conditional_effect_estimates = None

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -51,6 +51,7 @@ class CausalModel:
         :param estimand_type: the type of estimand requested (currently only "nonparametric-ate" is supported). In the future, may support other specific parametric forms of identification.
         :param proceed_when_unidentifiable: does the identification proceed by ignoring potential unobserved confounders. Binary flag.
         :param missing_nodes_as_confounders: Binary flag indicating whether variables in the dataframe that are not included in the causal graph, should be  automatically included as confounder nodes.
+        :param `**kwargs`: More optional parameters that can be passed to the causal model. Currently supported params: "logging_level" to indicate the level of logging needed. Possible values are logging.CRITICAL, logging.ERROR, logging.INFO, logging.WARNING,and logging.DEBUG. Default is logging.INFO.
         :returns: an instance of CausalModel class
 
         """


### PR DESCRIPTION
The OLS print now follows the logging_level set in CausalModel.
Fixes #144 