### PR TITLE
Generalize dummy outcome refuter

### DIFF
--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -166,8 +166,6 @@ class DummyOutcomeRefuter(CausalRefuter):
     DEFAULT_TRANSFORMATION = [("zero",""),("noise", {'std_dev': 1} )]
     # The Default True Causal Effect, this is taken to be ZERO by default
     DEFAULT_TRUE_CAUSAL_EFFECT = lambda x: 0
-    # The Default Split for the number of data points that go into the base or the validation set
-    DEFAULT_TEST_VALIDATION_SPLIT = [.5, .5]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -177,8 +175,6 @@ class DummyOutcomeRefuter(CausalRefuter):
         self._true_causal_effect = kwargs.pop("true_causal_effect", DummyOutcomeRefuter.DEFAULT_TRUE_CAUSAL_EFFECT)
         self._bucket_size_scale_factor = kwargs.pop("bucket_size_scale_factor", DummyOutcomeRefuter.DEFAULT_BUCKET_SCALE_FACTOR)
         self._min_data_point_threshold = kwargs.pop("min_data_point_threshold", DummyOutcomeRefuter.MIN_DATA_POINT_THRESHOLD)
-        self._test_validation_split = kwargs.pop("test_validation_split", None)
-
         required_variables = kwargs.pop("required_variables", True)
         
         if required_variables is False:

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 import pandas as pd
 import logging
-
+import pdb
 from collections import OrderedDict, namedtuple
 from dowhy.causal_refuter import CausalRefutation
 from dowhy.causal_refuter import CausalRefuter
@@ -252,8 +252,9 @@ class DummyOutcomeRefuter(CausalRefuter):
                 groups = self.preprocess_data_by_treatment()
                 for key_train, _ in groups:
                     base_train = groups.get_group(key_train).sample(frac=self._test_validation_split.base)
-                    base_validation = groups.get_group(key_train) - base_train
-                    base_validation.dropna()
+                    train_set = set( [ tuple(line) for line in base_train.values ] )
+                    total_set = set( [ tuple(line) for line in groups.get_group(key_train).values ] )
+                    base_validation = pd.DataFrame( list( total_set.difference(train_set) ), columns=base_train.columns )
 
                     X_train = base_train[self._chosen_variables].values
                     outcome_train = base_train['y'].values
@@ -265,7 +266,7 @@ class DummyOutcomeRefuter(CausalRefuter):
                     for key_validation, _ in groups:
                         if key_validation != key_train:
                             validation_df.append(groups.get_group(key_validation).sample(frac=self._test_validation_split.other))
-
+                    
                     validation_df = pd.concat(validation_df)
                     X_validation = validation_df[self._chosen_variables].values
                     outcome_validation = validation_df['y'].values

--- a/tests/causal_refuters/test_dummy_outcome_refuter.py
+++ b/tests/causal_refuters/test_dummy_outcome_refuter.py
@@ -17,11 +17,11 @@ class TestDummyOutcomeRefuter(object):
         refuter_tester = TestRefuter(error_tolerence, estimator_method, "dummy_outcome_refuter")
         refuter_tester.continuous_treatment_testsuite()
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","num_samples"],
-    #                          [(0.03, "backdoor.propensity_score_matching",1000)])
-    # def test_refutation_dummy_outcome_refuter_default_binary_treatment(self, error_tolerence, estimator_method, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, estimator_method, "dummy_outcome_refuter")
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","num_samples"],
+                             [(0.03, "backdoor.propensity_score_matching",1000)])
+    def test_refutation_dummy_outcome_refuter_default_binary_treatment(self, error_tolerence, estimator_method, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, estimator_method, "dummy_outcome_refuter")
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     @pytest.mark.parametrize(["error_tolerence","estimator_method", "transformations"],
                              [(0.03, "iv.instrumental_variable", [("zero",""),("noise", {'std_dev': 1} )] )] )
@@ -33,15 +33,15 @@ class TestDummyOutcomeRefuter(object):
 
         refuter_tester.continuous_treatment_testsuite()
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method", "transformations","num_samples"],
-    #                          [(0.03, "backdoor.propensity_score_matching", [("zero",""),("noise", {'std_dev': 1} )], 1000 )] )
-    # def test_refutation_dummy_outcome_refuter_randomly_generated_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence,
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter", 
-    #                                 transformations=transformations)
+    @pytest.mark.parametrize(["error_tolerence","estimator_method", "transformations","num_samples"],
+                             [(0.03, "backdoor.propensity_score_matching", [("zero",""),("noise", {'std_dev': 1} )], 1000 )] )
+    def test_refutation_dummy_outcome_refuter_randomly_generated_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence,
+                                    estimator_method, 
+                                    "dummy_outcome_refuter", 
+                                    transformations=transformations)
 
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     @pytest.mark.parametrize(["error_tolerence", "estimator_method", "transformations"],
                             [(0.03, "iv.instrumental_variable", [("permute", {'permute_fraction' :1} )] )] )
@@ -53,15 +53,15 @@ class TestDummyOutcomeRefuter(object):
 
         refuter_tester.continuous_treatment_testsuite()
 
-    # @pytest.mark.parametrize(["error_tolerence", "estimator_method", "transformations","num_samples"],
-    #                         [(0.05, "backdoor.propensity_score_matching", [("permute", {'permute_fraction' :1} )], 1000 )] )
-    # def test_refutation_dummy_outcome_refuter_permute_data_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence,
-    #                                 estimator_method,
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
+    @pytest.mark.parametrize(["error_tolerence", "estimator_method", "transformations","num_samples"],
+                            [(0.05, "backdoor.propensity_score_matching", [("permute", {'permute_fraction' :1} )], 1000 )] )
+    def test_refutation_dummy_outcome_refuter_permute_data_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence,
+                                    estimator_method,
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
 
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations"],
                              [(0.03, "iv.instrumental_variable",[(simple_linear_outcome_model, {}), ("noise", {'std_dev': 1} )] )])
@@ -72,14 +72,15 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
-    #                          [(0.03, "backdoor.propensity_score_matching",[(simple_linear_outcome_model, {}), ("noise", {'std_dev': 1} )], 1000 )])
-    # def test_refutation_dummy_outcome_refuter_custom_function_linear_regression_with_noise_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
+                             [(0.03, "backdoor.propensity_score_matching",[(simple_linear_outcome_model, {}), ("noise", {'std_dev': 1} )], 1000 )])
+    def test_refutation_dummy_outcome_refuter_custom_function_linear_regression_with_noise_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations"],
                              [(0.03, "iv.instrumental_variable",[("permute", {'permute_fraction':0.5}),(simple_linear_outcome_model, {}), ("noise", {'std_dev': 1} )] )])
@@ -90,14 +91,15 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
-    #                          [(0.03, "backdoor.propensity_score_matching",[("permute", 0.5),(simple_linear_outcome_model, {}), ("noise", {'std_dev': 1} )], 1000 )])
-    # def test_refutation_dummy_outcome_refuter_custom_function_linear_regression_with_permute_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
+                             [(0.03, "backdoor.propensity_score_matching",[("permute", {'permute_fraction':0.5}),(simple_linear_outcome_model, {}), ("noise", {'std_dev': 1} )], 1000 )])
+    def test_refutation_dummy_outcome_refuter_custom_function_linear_regression_with_permute_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations"],
@@ -109,14 +111,14 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
-    #                          [(0.01, "backdoor.propensity_score_matching",[("linear_regression",{}) , ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
-    # def test_refutation_dummy_outcome_refuter_internal_linear_regression_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
+                             [(0.01, "backdoor.propensity_score_matching",[("linear_regression",{}) , ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
+    def test_refutation_dummy_outcome_refuter_internal_linear_regression_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
 
     @pytest.mark.parametrize(["error_tolerence","estimator_method", "transformations"],
                              [(0.01, "iv.instrumental_variable",[("knn",{'n_neighbors':5}), ("zero",""), ("noise", {'std_dev': 1} )] )])
@@ -127,14 +129,14 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method", "transformations","num_samples"],
-    #                          [(0.01, "backdoor.propensity_score_matching",[("knn",{'n_neighbors':5}), ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
-    # def test_refutation_dummy_outcome_refuter_internal_knn_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
+    @pytest.mark.parametrize(["error_tolerence","estimator_method", "transformations","num_samples"],
+                             [(0.01, "backdoor.propensity_score_matching",[("knn",{'n_neighbors':5}), ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
+    def test_refutation_dummy_outcome_refuter_internal_knn_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(tests_to_run="atleast-one-common-cause", num_samples=num_samples)
     
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations", "num_samples"],
                              [(0.01, "iv.instrumental_variable",[("svm",{'C':1,'epsilon':0.2}), ("zero",""), ("noise", {'std_dev': 1} )], 10000 )])
@@ -145,14 +147,15 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(num_samples=num_samples, tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations", "num_samples"],
-    #                          [(0.01, "iv.instrumental_variable",[("svm",{'C':1,'epsilon':0.2}), ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
-    # def test_refutation_dummy_outcome_refuter_internal_svm_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(num_samples=num_samples, tests_to_run="atleast-one-common-cause")
+    @pytest.mark.xfail
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations", "num_samples"],
+                             [(0.01, "iv.instrumental_variable",[("svm",{'C':1,'epsilon':0.2}), ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
+    def test_refutation_dummy_outcome_refuter_internal_svm_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(num_samples=num_samples, tests_to_run="atleast-one-common-cause")
 
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
                              [(0.01, "iv.instrumental_variable",[("random_forest",{'max_depth':20}), ("zero",""), ("noise", {'std_dev': 1} )], 10000)])
@@ -163,14 +166,14 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(num_samples,tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
-    #                          [(0.01, "backdoor.propensity_score_matching",[("random_forest",{'max_depth':20}), ("zero",""), ("noise", {'std_dev': 1} )], 1000)])
-    # def test_refutation_dummy_outcome_refuter_internal_random_forest_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(num_samples,tests_to_run="atleast-one-common-cause")
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
+                             [(0.01, "backdoor.propensity_score_matching",[("random_forest",{'max_depth':20}), ("zero",""), ("noise", {'std_dev': 1} )], 1000)])
+    def test_refutation_dummy_outcome_refuter_internal_random_forest_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(num_samples,tests_to_run="atleast-one-common-cause")
 
     # As we run with only one common cause and one instrument variable we run with (?, 2)
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations"],
@@ -182,11 +185,11 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(tests_to_run="atleast-one-common-cause")
 
-    # @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
-    #                          [(0.01, "backdoor.propensity_score_matching",[("neural_network",{'solver':'lbfgs', 'alpha':1e-5, 'hidden_layer_sizes':(5,2)}), ("zero",""), ("noise", {'std_dev': 1} )], 1000  )])
-    # def test_refutation_dummy_outcome_refuter_internal_neural_network_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
-    #     refuter_tester = TestRefuter(error_tolerence, 
-    #                                 estimator_method, 
-    #                                 "dummy_outcome_refuter",
-    #                                 transformations=transformations)
-    #     refuter_tester.binary_treatment_testsuite(num_samples=num_samples, tests_to_run="atleast-one-common-cause")
+    @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations","num_samples"],
+                             [(0.01, "backdoor.propensity_score_matching",[("neural_network",{'solver':'lbfgs', 'alpha':1e-5, 'hidden_layer_sizes':(5,2)}), ("zero",""), ("noise", {'std_dev': 1} )], 1000  )])
+    def test_refutation_dummy_outcome_refuter_internal_neural_network_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
+        refuter_tester = TestRefuter(error_tolerence, 
+                                    estimator_method, 
+                                    "dummy_outcome_refuter",
+                                    transformations=transformations)
+        refuter_tester.binary_treatment_testsuite(num_samples=num_samples, tests_to_run="atleast-one-common-cause")

--- a/tests/causal_refuters/test_dummy_outcome_refuter.py
+++ b/tests/causal_refuters/test_dummy_outcome_refuter.py
@@ -147,9 +147,8 @@ class TestDummyOutcomeRefuter(object):
                                     transformations=transformations)
         refuter_tester.continuous_treatment_testsuite(num_samples=num_samples, tests_to_run="atleast-one-common-cause")
 
-    @pytest.mark.xfail
     @pytest.mark.parametrize(["error_tolerence","estimator_method","transformations", "num_samples"],
-                             [(0.01, "iv.instrumental_variable",[("svm",{'C':1,'epsilon':0.2}), ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
+                             [(0.01, "backdoor.propensity_score_matching",[("svm",{'C':1,'epsilon':0.2}), ("zero",""), ("noise", {'std_dev': 1} )], 1000 )])
     def test_refutation_dummy_outcome_refuter_internal_svm_binary_treatment(self, error_tolerence, estimator_method, transformations, num_samples):
         refuter_tester = TestRefuter(error_tolerence, 
                                     estimator_method, 


### PR DESCRIPTION
The earlier version of the dummy outcome refuter could not handle binary treatments. Thus, in this PR, we overcome this problem, by shifting a portion of the test treatment into the validation, so as to ensure, sufficient variation in the validation set. Furthermore, this has been generalized, to allow a user to sample a portion of the non-base categories.