### PR TITLE
refactor identify backdoor to reduce code redundancy

### DIFF
--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -127,7 +127,7 @@ class CausalModel:
         self.summary()
 
     def identify_effect(self, estimand_type=None,
-            method_name="auto", proceed_when_unidentifiable=None):
+            method_name="default", proceed_when_unidentifiable=None):
         """Identify the causal effect to be estimated, using properties of the causal graph.
 
         :param proceed_when_unidentifiable: Binary flag indicating whether identification should proceed in the presence of (potential) unobserved confounders.


### PR DESCRIPTION
A small refactoring of `CausalIdentifier.identify_backdoor`, which contained some duplicated code I though could be tidied up.

Only two methods for effect identification are now supported, and both of them propagate only to the `identify_backdoor`, The difference in logic is quite minor, in the sense that the one stops as soon as a valid adjustment set is found, and the other continues on to search the whole space.

The other difference was that exhaustive method was searching from the smallest adjustment set to the largest, while the other one was doing in reverse, from largest to smallest. It doesn't seem that important to me, but I could be wrong, so please let me know.

Tests are in general missing for causal identifiers, it would be a good idea to make some as a next step. :)