### PR TITLE
remove basic logging configuration

### DIFF
--- a/dowhy/__init__.py
+++ b/dowhy/__init__.py
@@ -1,6 +1,8 @@
+import logging
 from os import path
 from dowhy.causal_model import CausalModel
 
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 here = path.abspath(path.dirname(__file__))
 # Loading version number

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -50,7 +50,6 @@ class CausalModel:
         :param estimand_type: the type of estimand requested (currently only "nonparametric-ate" is supported). In the future, may support other specific parametric forms of identification.
         :param proceed_when_unidentifiable: does the identification proceed by ignoring potential unobserved confounders. Binary flag.
         :param missing_nodes_as_confounders: Binary flag indicating whether variables in the dataframe that are not included in the causal graph, should be  automatically included as confounder nodes.
-        :param `**kwargs`: More optional parameters that can be passed to the causal model. Currently supported params: "logging_level" to indicate the level of logging needed. Possible values are logging.CRITICAL, logging.ERROR, logging.INFO, logging.WARNING,and logging.DEBUG. Default is logging.INFO.
         :returns: an instance of CausalModel class
 
         """
@@ -61,12 +60,6 @@ class CausalModel:
         self._estimand_type = estimand_type
         self._proceed_when_unidentifiable = proceed_when_unidentifiable
         self._missing_nodes_as_confounders = missing_nodes_as_confounders
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
-
-        # TODO: move the logging level argument to a json file. Tue 20 Feb 2018 06:56:27 PM DST
         self.logger = logging.getLogger(__name__)
 
         if graph is None:

--- a/dowhy/causal_refuter.py
+++ b/dowhy/causal_refuter.py
@@ -27,10 +27,6 @@ class CausalRefuter:
             self._random_seed = kwargs['random_seed']
             np.random.seed(self._random_seed)
 
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
 
         # Concatenate the confounders, instruments and effect modifiers

--- a/dowhy/causal_refuters/add_unobserved_common_cause.py
+++ b/dowhy/causal_refuters/add_unobserved_common_cause.py
@@ -44,10 +44,6 @@ class AddUnobservedCommonCause(CausalRefuter):
         self.kappa_y = kwargs["effect_strength_on_outcome"] if "effect_strength_on_outcome" in kwargs else None
         self.simulated_method_name = kwargs["simulated_method_name"] if "simulated_method_name" in kwargs else "linear_based"
 
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
 
     def refute_estimate(self):

--- a/dowhy/causal_refuters/bootstrap_refuter.py
+++ b/dowhy/causal_refuters/bootstrap_refuter.py
@@ -61,10 +61,6 @@ class BootstrapRefuter(CausalRefuter):
         self._probability_of_change = kwargs.pop("probability_of_change", None)
         self._random_state = kwargs.pop("random_state", None)
 
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
         
         self._chosen_variables = self.choose_variables(required_variables)

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -26,10 +26,6 @@ class DataSubsetRefuter(CausalRefuter):
         self._num_simulations = kwargs.pop("num_simulations", CausalRefuter.DEFAULT_NUM_SIMULATIONS )
         self._random_state = kwargs.pop("random_state",None)
 
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
 
     def refute_estimate(self):

--- a/dowhy/causal_refuters/dummy_outcome_refuter.py
+++ b/dowhy/causal_refuters/dummy_outcome_refuter.py
@@ -193,11 +193,6 @@ class DummyOutcomeRefuter(CausalRefuter):
 
         self._chosen_variables = self.choose_variables(required_variables)
 
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
-        
         self.logger = logging.getLogger(__name__)
 
     def refute_estimate(self):

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -40,11 +40,6 @@ class PlaceboTreatmentRefuter(CausalRefuter):
         self._num_simulations = kwargs.pop("num_simulations",CausalRefuter.DEFAULT_NUM_SIMULATIONS)
         self._random_state = kwargs.pop("random_state",None)
 
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
-
         self.logger = logging.getLogger(__name__)
 
 

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -17,13 +17,7 @@ class TestRefuter(object):
         self.confounders_effect_on_y = confounders_effect_on_y
         self.effect_strength_on_t = effect_strength_on_t
         self.effect_strength_on_y = effect_strength_on_y
-
-        if 'logging_level' in kwargs:
-            logging.basicConfig(level=kwargs['logging_level'])
-        else:
-            logging.basicConfig(level=logging.INFO)
         self.logger = logging.getLogger(__name__)
-
         self.logger.debug(self._error_tolerance)
 
     def null_refutation_test(self, data=None, dataset="linear", beta=10,


### PR DESCRIPTION
When `basicConfig` is called, logging is set up automatically and unless
a `logging.NullHandler` instance is included with each call it becomes
very difficult to control logging from DoWhy. This change removes all
calls to `basicConfig` and adds a `NullHandler` to the root DoWhy
logger. Now, users of DoWhy can configure their logging preference
through something like `logging.config.dictConfig` with a reference to
`dowhy` in the `loggers` section of the configuration.