### PR TITLE
handle missing identifier method for getting backdoor variables

### DIFF
--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -610,7 +610,7 @@ class IdentifiedEstimand:
             Otherwise, return the backdoor variables for the default backdoor estimand.
         """
         if key is None:
-            if self.identifier_method.startswith("backdoor"):
+            if self.identifier_method and self.identifier_method.startswith("backdoor"):
                 return self.backdoor_variables[self.identifier_method]
             else:
                 return self.backdoor_variables[self.default_backdoor_id]


### PR DESCRIPTION
Closes microsoft/dowhy#232