### PR TITLE
Backdoor identification tests

### DIFF
--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -1,8 +1,10 @@
+import itertools
 import logging
 import re
+
 import networkx as nx
+
 from dowhy.utils.api import parse_state
-import itertools
 
 
 class CausalGraph:
@@ -344,7 +346,11 @@ class CausalGraph:
         return True
 
     def get_all_nodes(self, include_unobserved=True):
-        return self._graph.nodes
+        nodes = self._graph.nodes
+        if not include_unobserved:
+            nodes = set(self.filter_unobserved_variables(nodes))
+        
+        return nodes
 
     def filter_unobserved_variables(self, node_names):
         observed_node_names = list()

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -276,13 +276,13 @@ class CausalIdentifier:
                         num_iterations += 1
                         if method_name == CausalIdentifier.BACKDOOR_EXHAUSTIVE and num_iterations > CausalIdentifier.MAX_BACKDOOR_ITERATIONS:
                             break
-                # If the backdoor method is `maximum-possible`, return the first valid adjustment set, which is the maximum possible one.
+                # If the backdoor method is `maximal-adjustment`, return the first valid adjustment set, which is the maximum possible one.
                 if method_name == CausalIdentifier.BACKDOOR_MAX and found_valid_adjustment_set:
                     break
         else:
             raise ValueError(f"Identifier method {method_name} not supported. Try one of the following: {CausalIdentifier.METHOD_NAMES}")
         
-        # If method name is `minimum-sufficient` return the backdoor sets with lowest possible cardinality.
+        # If method name is `minimal-adjustment` return the backdoor sets with lowest possible cardinality.
         if method_name == CausalIdentifier.BACKDOOR_MIN and len(backdoor_sets) > 0:
             min_set_size = min([len(bset["backdoor_set"]) for bset in backdoor_sets])
             backdoor_sets = [bset for bset in backdoor_sets if len(bset["backdoor_set"]) == min_set_size]

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -254,9 +254,9 @@ class CausalIdentifier:
         # Second, checking for all other sets of variables
         eligible_variables = self._graph.get_all_nodes() \
             - set(treatment_name) \
-            - set(outcome_name) 
+            - set(outcome_name)
         eligible_variables -= self._graph.get_descendants(treatment_name)
-
+        
         num_iterations = 0
         found_valid_adjustment_set = False
         method_name = self.method_name if self.method_name != CausalIdentifier.BACKDOOR_DEFAULT else CausalIdentifier.DEFAULT_BACKDOOR_METHOD

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -300,12 +300,12 @@ class CausalIdentifier:
         iv_count_dict = {key: len(set(bdoor_set).intersection(instrument_names)) for key, bdoor_set in backdoor_sets_dict.items()}
         min_iv_count = min(iv_count_dict.values())
         min_iv_keys = {key for key, iv_count in iv_count_dict.items() if iv_count == min_iv_count}
-        backdoor_sets_dict = {key: backdoor_sets_dict[key] for key in min_iv_keys}
+        min_iv_backdoor_sets_dict = {key: backdoor_sets_dict[key] for key in min_iv_keys}
 
         # Default set is the one with the most number of adjustment variables (optimizing for minimum (unknown) bias not for efficiency)
         max_set_length = -1
         default_key = None
-        for key, bdoor_set in backdoor_sets_dict.items():
+        for key, bdoor_set in min_iv_backdoor_sets_dict.items():
             if len(bdoor_set) > max_set_length:
                 max_set_length = len(bdoor_set)
                 default_key = key

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -247,8 +247,7 @@ class CausalIdentifier:
         # Second, checking for all other sets of variables
         eligible_variables = self._graph.get_all_nodes() \
             - set(treatment_name) \
-            - set(outcome_name) \
-            - set(self._graph.get_instruments(treatment_name, outcome_name))
+            - set(outcome_name) 
         eligible_variables -= self._graph.get_descendants(treatment_name)
 
         num_iterations = 0

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -27,8 +27,8 @@ class CausalIdentifier:
     # Backdoor method names
     BACKDOOR_DEFAULT="default"
     BACKDOOR_EXHAUSTIVE="exhaustive-search"
-    BACKDOOR_MIN="minimum-sufficient"
-    BACKDOOR_MAX="maximum-possible"
+    BACKDOOR_MIN="minimal-adjustment"
+    BACKDOOR_MAX="maximal-adjustment"
     METHOD_NAMES = {BACKDOOR_DEFAULT, BACKDOOR_EXHAUSTIVE, BACKDOOR_MIN, BACKDOOR_MAX}
     DEFAULT_BACKDOOR_METHOD = BACKDOOR_MAX
 

--- a/dowhy/causal_identifier.py
+++ b/dowhy/causal_identifier.py
@@ -233,7 +233,7 @@ class CausalIdentifier:
 
 
 
-    def identify_backdoor(self, treatment_name, outcome_name):
+    def identify_backdoor(self, treatment_name, outcome_name, include_unobserved=False):
         backdoor_sets = []
         backdoor_paths = self._graph.get_backdoor_paths(treatment_name, outcome_name)
         # First, checking if empty set is a valid backdoor set
@@ -275,11 +275,11 @@ class CausalIdentifier:
         #causes_y = self._graph.get_causes(self.outcome_name, remove_edges={'sources':self.treatment_name, 'targets':self.outcome_name})
         #common_causes = list(causes_t.intersection(causes_y))
         #self.logger.info("Common causes of treatment and outcome:" + str(common_causes))
-        observed_backdoor_sets = [ bset for bset in backdoor_sets if self._graph.all_observed(bset["backdoor_set"])]
-        if len(observed_backdoor_sets)==0:
+        
+        if include_unobserved:
             return backdoor_sets
         else:
-            return observed_backdoor_sets
+            return [bset for bset in backdoor_sets if self._graph.all_observed(bset["backdoor_set"])]
 
     def get_default_backdoor_set_id(self, backdoor_sets_dict):
         # Adding a None estimand if no backdoor set found

--- a/tests/causal_identifiers/base.py
+++ b/tests/causal_identifiers/base.py
@@ -6,13 +6,12 @@ from .example_graphs import TEST_GRAPH_SOLUTIONS
 
 class IdentificationTestGraphSolution(object):
 
-    def __init__(self, graph_str, observed_variables, biased_sets, minimal_adjustment_sets, maximal_adjustment_sets, adjustment_not_necessary):
+    def __init__(self, graph_str, observed_variables, biased_sets, minimal_adjustment_sets, maximal_adjustment_sets):
         self.graph = CausalGraph("X", "Y", graph_str, observed_node_names=observed_variables)
         self.observed_variables = observed_variables
         self.biased_sets = biased_sets
         self.minimal_adjustment_sets = minimal_adjustment_sets
         self.maximal_adjustment_sets = maximal_adjustment_sets
-        self.adjustment_not_necessary = adjustment_not_necessary
 
 
 @pytest.fixture(params=TEST_GRAPH_SOLUTIONS.keys())

--- a/tests/causal_identifiers/base.py
+++ b/tests/causal_identifiers/base.py
@@ -6,11 +6,13 @@ from .example_graphs import TEST_GRAPH_SOLUTIONS
 
 class IdentificationTestGraphSolution(object):
 
-    def __init__(self, graph_str, observed_variables, biased_sets, expected_sets):
+    def __init__(self, graph_str, observed_variables, biased_sets, minimal_adjustment_sets, maximal_adjustment_sets, adjustment_not_necessary):
         self.graph = CausalGraph("X", "Y", graph_str, observed_node_names=observed_variables)
         self.observed_variables = observed_variables
         self.biased_sets = biased_sets
-        self.expected_sets = expected_sets
+        self.minimal_adjustment_sets = minimal_adjustment_sets
+        self.maximal_adjustment_sets = maximal_adjustment_sets
+        self.adjustment_not_necessary = adjustment_not_necessary
 
 
 @pytest.fixture(params=TEST_GRAPH_SOLUTIONS.keys())

--- a/tests/causal_identifiers/base.py
+++ b/tests/causal_identifiers/base.py
@@ -1,0 +1,18 @@
+import pytest
+from dowhy.causal_graph import CausalGraph
+
+from .example_graphs import TEST_GRAPH_SOLUTIONS
+
+
+class IdentificationTestGraphSolution(object):
+
+    def __init__(self, graph_str, observed_variables, biased_sets, expected_sets):
+        self.graph = CausalGraph("X", "Y", graph_str, observed_node_names=observed_variables)
+        self.observed_variables = observed_variables
+        self.biased_sets = biased_sets
+        self.expected_sets = expected_sets
+
+
+@pytest.fixture(params=TEST_GRAPH_SOLUTIONS.keys())
+def example_graph_solution(request):
+    return IdentificationTestGraphSolution(**TEST_GRAPH_SOLUTIONS[request.param])

--- a/tests/causal_identifiers/example_graphs.py
+++ b/tests/causal_identifiers/example_graphs.py
@@ -6,9 +6,9 @@ Each example graph is contained of the following values:
     * graph_str - The graph string in GML format.
     * observed_variables - A list of observed variables in the graph. This will be used to test no unobserved variables are offered in the solution.
     * biased_sets - The sets that we shouldn't get in the output as they incur biased estimates of the causal effect.
-    * minimal_adjustment_sets - Sets of observed variables that should be returned when 'minimal-adjustment' is specified as the backdoor method. Contains the empty set as well.
+    * minimal_adjustment_sets - Sets of observed variables that should be returned when 'minimal-adjustment' is specified as the backdoor method. 
+        If no adjustment is necessary given the graph, minimal adjustment set should be the empty set.
     * maximal_adjustment_sets - Sets of observed variables that should be returned when 'maximal-adjustment' is specified as the backdoor method.
-    * exhaustive_search_sets - Sets of observed variables that we want to check as the output of 'exhaustive-search' backdoor method. 'minimal-adjustment' and 'maximal-adjustment' will be included here.
 """
 
 TEST_GRAPH_SOLUTIONS = {
@@ -34,10 +34,9 @@ TEST_GRAPH_SOLUTIONS = {
                         edge[source "X" target "Z6"]]    
                     """,
         observed_variables = ["Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "X", "Y"],
-        biased_sets = [{"Z4"}, {"Z6"}, {"Z5"}, {"Z2"}, {"Z1"}, {"Z3",}, {"Z1", "Z3"}, {"Z2", "Z5"}, {"Z1", "Z2"}],
+        biased_sets = [{"Z4"}, {"Z6"}, {"Z5"}, {"Z2"}, {"Z1"}, {"Z3"}, {"Z1", "Z3"}, {"Z2", "Z5"}, {"Z1", "Z2"}],
         minimal_adjustment_sets = [{"Z1", "Z4"}, {"Z2", "Z4"}, {"Z3", "Z4"}, {"Z5", "Z4"}],
-        maximal_adjustment_sets = [{"Z1", "Z2", "Z3", "Z4", "Z5"}],
-        adjustment_not_necessary = False
+        maximal_adjustment_sets = [{"Z1", "Z2", "Z3", "Z4", "Z5"}]
     ),
     "simple_selection_bias_graph": dict(
         graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
@@ -50,8 +49,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["Z1", "X", "Y"],
         biased_sets = [{"Z1",}], 
         minimal_adjustment_sets = [{}],
-        maximal_adjustment_sets = [],
-        adjustment_not_necessary = True
+        maximal_adjustment_sets = [{}]
     ),
     "simple_no_confounder_graph": dict(
         graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
@@ -63,8 +61,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables=["Z1", "X", "Y"],
         biased_sets = [],
         minimal_adjustment_sets = [{}],
-        maximal_adjustment_sets = [{"Z1",}],
-        adjustment_not_necessary = True
+        maximal_adjustment_sets = [{"Z1",}]
     ),
     # The following simpsons paradox examples are taken from Pearl, J {2013}. "Understanding Simpson’s Paradox" - http://ftp.cs.ucla.edu/pub/stat_ser/r414.pdf
     "pearl_simpsons_paradox_1c": dict(
@@ -82,8 +79,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables=["Z", "X", "Y"],
         biased_sets = [{"Z",}],
         minimal_adjustment_sets = [{}],
-        maximal_adjustment_sets = [],
-        adjustment_not_necessary = True
+        maximal_adjustment_sets = [{}]
     ),
     "pearl_simpsons_paradox_1d": dict(
         graph_str = """graph[directed 1 node[id "Z" label "Z"]  
@@ -98,8 +94,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["Z", "X", "Y"],
         biased_sets = [],
         minimal_adjustment_sets = [{"Z",}],
-        maximal_adjustment_sets = [{"Z",}],
-        adjustment_not_necessary = False
+        maximal_adjustment_sets = [{"Z",}]
     ),
     "pearl_simpsons_paradox_2a": dict(
         graph_str = """graph[directed 1 node[id "Z" label "Z"]  
@@ -114,8 +109,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["Z", "X", "Y"],
         biased_sets = [{"Z", }],
         minimal_adjustment_sets = [{}],
-        maximal_adjustment_sets = [{}],
-        adjustment_not_necessary = True
+        maximal_adjustment_sets = [{}]
     ),
     "pearl_simpsons_paradox_2b": dict(
         graph_str = """graph[directed 1 node[id "Z" label "Z"]  
@@ -129,8 +123,21 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["Z", "X", "Y"],
         biased_sets = [], 
         minimal_adjustment_sets = [],
-        maximal_adjustment_sets = [], # Should this be {"Z"}?
-        adjustment_not_necessary = False
+        maximal_adjustment_sets = [] # Should this be {"Z"}?
+    ),
+    "pearl_simpsons_paradox_2b_L_observed": dict(
+        graph_str = """graph[directed 1 node[id "Z" label "Z"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "L" label "L"]      
+                edge[source "X" target "Y"]
+                edge[source "Z" target "X"]
+                edge[source "L" target "X"]
+                edge[source "L" target "Y"]]""",
+        observed_variables = ["Z", "X", "Y", "L"],
+        biased_sets = [], 
+        minimal_adjustment_sets = [{"L"}],
+        maximal_adjustment_sets = [{"L", "Z"}]
     ),
     "pearl_simpsons_machine_lvl1": dict(
         graph_str = """graph[directed 1 node[id "Z1" label "Z1"]
@@ -149,8 +156,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables=["Z1", "Z2", "Z3", "X", "Y"],
         biased_sets = [{"Z2",}, {"Z1", "Z2"}],
         minimal_adjustment_sets = [{}],
-        maximal_adjustment_sets = [{"Z1", "Z2", "Z3"}],
-        adjustment_not_necessary = True
+        maximal_adjustment_sets = [{"Z1", "Z2", "Z3"}]
     ),
     # The following are examples given in the "Book of Why" by Judea Pearl, chapter "The Do-operator and the Back-Door Criterion"
     "book_of_why_game2": dict(
@@ -172,8 +178,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["A", "B", "C", "D", "E", "X", "Y"],
         biased_sets = [{"B",}, {"C",}, {"B", "C"}],
         minimal_adjustment_sets = [{}],
-        maximal_adjustment_sets = [{"A", "B", "C", "D"}],
-        adjustment_not_necessary = True
+        maximal_adjustment_sets = [{"A", "B", "C", "D"}]
     ),
     "book_of_why_game5": dict(
         graph_str = """graph[directed 1 node[id "A" label "A"]
@@ -191,8 +196,7 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["A", "B", "C", "X", "Y"],
         biased_sets = [{"B",}],
         minimal_adjustment_sets = [{"C"}],
-        maximal_adjustment_sets = [{"A", "B", "C"}],
-        adjustment_not_necessary = False
+        maximal_adjustment_sets = [{"A", "B", "C"}]
     ),
     "book_of_why_game5_C_is_unobserved": dict(
         graph_str = """graph[directed 1 node[id "A" label "A"]
@@ -210,8 +214,56 @@ TEST_GRAPH_SOLUTIONS = {
         observed_variables = ["A", "B", "X", "Y"],
         biased_sets = [{"B",}],
         minimal_adjustment_sets = [{"A", "B"}],
-        maximal_adjustment_sets = [{"A", "B"}],
-        adjustment_not_necessary = False
+        maximal_adjustment_sets = [{"A", "B"}]
+    ),
+    "no_treatment_but_valid_maximal_set": dict(
+        graph_str = """graph[directed 1 node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "Z1" label "Z1"]
+                node[id "Z2" label "Z2"]      
+                edge[source "X" target "Y"]
+                edge[source "X" target "Z1"]
+                edge[source "Z1" target "Y"]
+                edge[source "Z2" target "Z1"]]
+                """,
+        observed_variables = ["Z1", "Z2", "X", "Y"],
+        biased_sets = [],
+        minimal_adjustment_sets = [{}],
+        maximal_adjustment_sets = [{"Z2"}]
+    ),
+    "common_cause_of_mediator1": dict(
+        graph_str = """graph[directed 1 node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "U" label "U"]
+                node[id "Z" label "Z"]
+                node[id "M" label "M"]
+                edge[source "X" target "M"]
+                edge[source "M" target "Y"]
+                edge[source "U" target "X"]
+                edge[source "U" target "Z"]
+                edge[source "Z" target "M"]]
+                """,
+        observed_variables = ["X", "Y", "Z", "M"],
+        biased_sets = [],
+        minimal_adjustment_sets = [{"Z"}],
+        maximal_adjustment_sets = [{"Z"}]
+    ),
+    "common_cause_of_mediator2": dict(
+        graph_str = """graph[directed 1 node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "U" label "U"]
+                node[id "Z" label "Z"]
+                node[id "M" label "M"]
+                edge[source "X" target "M"]
+                edge[source "M" target "Y"]
+                edge[source "U" target "Z"]
+                edge[source "U" target "M"]
+                edge[source "Z" target "X"]]
+                """,
+        observed_variables = ["X", "Y", "Z", "M"],
+        biased_sets = [],
+        minimal_adjustment_sets = [{"Z"}],
+        maximal_adjustment_sets = [{"Z"}]
     )
 
 

--- a/tests/causal_identifiers/example_graphs.py
+++ b/tests/causal_identifiers/example_graphs.py
@@ -12,6 +12,7 @@ Each example graph is contained of the following values:
 """
 
 TEST_GRAPH_SOLUTIONS = {
+    # Example is selected from Pearl J. "Causality" 2nd Edition, from chapter 3.3.1 on backoor criterion.
     "pearl_backdoor_example_graph": dict(
         graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
                         node[id "Z2" label "Z2"]
@@ -135,7 +136,7 @@ TEST_GRAPH_SOLUTIONS = {
         biased_sets = [("Z2",), ("Z1", "Z2")],
         expected_sets = [("Z1",), ("Z3",)]
     ),
-    # The following are examples given in the "Book of Why" by Judea Pearl.
+    # The following are examples given in the "Book of Why" by Judea Pearl, chapter "The Do-operator and the Back-Door Criterion"
     "book_of_why_game2": dict(
         graph_str = """graph[directed 1 node[id "A" label "A"]
                 node[id "B" label "B"]

--- a/tests/causal_identifiers/example_graphs.py
+++ b/tests/causal_identifiers/example_graphs.py
@@ -1,0 +1,203 @@
+"""
+The example below illustrate some of the common examples of causal graph in books.
+This file is meant to group all of the graph definitions as well as the expected results of identification algorithms in one place.
+Each example graph is contained of the following values:
+
+    * graph_str - The graph string in GML format.
+    * observed_variables - A list of observed variables in the graph. This will be used to test no unobserved variables are offered in the solution.
+    * biased_sets - The sets that we shouldn't get in the output as they incur biased estimates of the causal effect.
+    * expected_sets - A list of sets we expect to see and explicitely check for them in our tests. 
+                    These are usually not containing all the possible adjustment sets, and commonly contain only the 
+                    minimum sufficient adjustment sets.
+"""
+
+TEST_GRAPH_SOLUTIONS = {
+    "pearl_backdoor_example_graph": dict(
+        graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
+                        node[id "Z2" label "Z2"]
+                        node[id "Z3" label "Z3"]
+                        node[id "Z4" label "Z4"]
+                        node[id "Z5" label "Z5"]
+                        node[id "Z6" label "Z6"]
+                        node[id "X" label "X"]
+                        node[id "Y" label "Y"]      
+                        edge[source "Z1" target "Z3"]
+                        edge[source "Z1" target "Z4"]
+                        edge[source "Z2" target "Z4"]
+                        edge[source "Z2" target "Z5"]
+                        edge[source "Z3" target "X"]
+                        edge[source "Z4" target "X"]
+                        edge[source "Z4" target "Y"]
+                        edge[source "Z5" target "Y"]
+                        edge[source "Z6" target "Y"]
+                        edge[source "X" target "Z6"]]    
+                    """,
+        observed_variables = ["Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "X", "Y"],
+        biased_sets = [("Z4",), ("Z6",), ("Z5",), ("Z2",), ("Z1",), ("Z3",), ("Z1", "Z3"), ("Z2", "Z5"), ("Z1", "Z2")],
+        expected_sets = [("Z1", "Z4"), ("Z2", "Z4"), ("Z3", "Z4"), ("Z5", "Z4")] 
+    ),
+    "simple_selection_bias_graph": dict(
+        graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
+                    node[id "X" label "X"]
+                    node[id "Y" label "Y"]      
+                    edge[source "X" target "Y"]
+                    edge[source "X" target "Z1"]
+                    edge[source "Y" target "Z1"]]
+                    """,
+        observed_variables = ["Z1", "X", "Y"],
+        biased_sets = [("Z1",)], 
+        expected_sets = []
+    ),
+    "simple_no_confounder_graph": dict(
+        graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]      
+                edge[source "X" target "Y"]
+                edge[source "Z1" target "X"]]
+                """,
+        observed_variables=["Z1", "X", "Y"],
+        biased_sets = [],
+        expected_sets = []
+    ),
+    # The following simpsons paradox examples are taken from Pearl, J (2013). "Understanding Simpson’s Paradox" - http://ftp.cs.ucla.edu/pub/stat_ser/r414.pdf
+    "pearl_simpsons_paradox_1c": dict(
+        graph_str = """graph[directed 1 node[id "Z" label "Z"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "L1" label "L1"]
+                node[id "L2" label "L2"]      
+                edge[source "X" target "Y"]
+                edge[source "L1" target "X"]
+                edge[source "L1" target "Z"]
+                edge[source "L2" target "Z"]
+                edge[source "L2" target "Y"]]
+                """,
+        observed_variables=["Z", "X", "Y"],
+        biased_sets = [("Z",)],
+        expected_sets = []
+    ),
+    "pearl_simpsons_paradox_1d": dict(
+        graph_str = """graph[directed 1 node[id "Z" label "Z"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "L1" label "L1"]
+                edge[source "X" target "Y"]
+                edge[source "L1" target "X"]
+                edge[source "L1" target "Z"]
+                edge[source "Z" target "Y"]]
+                """,
+        observed_variables = ["Z", "X", "Y"],
+        biased_sets = [],
+        expected_sets = [("Z", )]
+    ),
+    "pearl_simpsons_paradox_2a": dict(
+        graph_str = """graph[directed 1 node[id "Z" label "Z"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "L" label "L"]      
+                edge[source "X" target "Y"]
+                edge[source "X" target "Z"]
+                edge[source "L" target "Z"]
+                edge[source "L" target "Y"]]
+                """,
+        observed_variables = ["Z", "X", "Y"],
+        biased_sets = [("Z", )],
+        expected_sets = []
+    ),
+    "pearl_simpsons_paradox_2b": dict(
+        graph_str = """graph[directed 1 node[id "Z" label "Z"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                node[id "L" label "L"]      
+                edge[source "X" target "Y"]
+                edge[source "Z" target "X"]
+                edge[source "L" target "X"]
+                edge[source "L" target "Y"]]""",
+        observed_variables = ["Z", "X", "Y"],
+        biased_sets = [], 
+        expected_sets = []
+    ),
+    "pearl_simpsons_machine_lvl1": dict(
+        graph_str = """graph[directed 1 node[id "Z1" label "Z1"]
+                node[id "Z2" label "Z2"]
+                node[id "Z3" label "Z3"]
+                node[id "L" label "L"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                edge[source "X" target "Y"]
+                edge[source "Z1" target "L"]
+                edge[source "L" target "Z2"]
+                edge[source "Z3" target "Z2"]
+                edge[source "L" target "X"]
+                edge[source "Z3" target "Y"]]
+                """,
+        observed_variables=["Z1", "Z2", "Z3", "X", "Y"],
+        biased_sets = [("Z2",), ("Z1", "Z2")],
+        expected_sets = [("Z1",), ("Z3",)]
+    ),
+    # The following are examples given in the "Book of Why" by Judea Pearl.
+    "book_of_why_game2": dict(
+        graph_str = """graph[directed 1 node[id "A" label "A"]
+                node[id "B" label "B"]
+                node[id "C" label "C"]
+                node[id "D" label "D"]  
+                node[id "E" label "E"]
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                edge[source "A" target "X"]
+                edge[source "A" target "B"]
+                edge[source "B" target "C"]
+                edge[source "D" target "B"]
+                edge[source "D" target "E"]
+                edge[source "X" target "E"]
+                edge[source "E" target "Y"]]
+                """,
+        observed_variables = ["A", "B", "C", "D", "E", "X", "Y"],
+        biased_sets = [("B",), ("C",), ("B", "C")],
+        expected_sets = []
+    ),
+    "book_of_why_game5": dict(
+        graph_str = """graph[directed 1 node[id "A" label "A"]
+                node[id "B" label "B"]
+                node[id "C" label "C"]
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                edge[source "A" target "X"]
+                edge[source "A" target "B"]
+                edge[source "B" target "X"]
+                edge[source "C" target "B"]
+                edge[source "C" target "Y"]
+                edge[source "X" target "Y"]]
+                """,
+        observed_variables = ["A", "B", "C", "X", "Y"],
+        biased_sets = [("B",)],
+        expected_sets = [("C",), ("B", "C"), ("B", "A")]
+    ),
+    "book_of_why_game5_C_is_unobserved": dict(
+        graph_str = """graph[directed 1 node[id "A" label "A"]
+                node[id "B" label "B"]
+                node[id "C" label "C"]
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]
+                edge[source "A" target "X"]
+                edge[source "A" target "B"]
+                edge[source "B" target "X"]
+                edge[source "C" target "B"]
+                edge[source "C" target "Y"]
+                edge[source "X" target "Y"]]
+                """,
+        observed_variables = ["A", "B", "C", "X", "Y"],
+        biased_sets = [("B",), ],
+        expected_sets = [("B", "A")]
+    )
+
+
+}
+
+
+
+
+
+
+
+

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -4,8 +4,8 @@ from dowhy.causal_identifier import CausalIdentifier
 
 from .base import IdentificationTestGraphSolution, example_graph_solution
 
-# TODO: How to differentiate when no adjustment is needed from when no adjustment exists?
 
+# TODO: How to differentiate when no adjustment is needed from when no adjustment exists?
 class TestBackdoorIdentification(object):
 
     def test_identify_backdoor_no_biased_sets(self, example_graph_solution: IdentificationTestGraphSolution):

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -1,0 +1,133 @@
+import pytest
+from dowhy.causal_graph import CausalGraph
+from dowhy.causal_identifier import CausalIdentifier
+
+# TODO: What does num_paths_blocked_by_observed_nodes mean?
+# TODO: Test no duplicates in sets
+# TODO: Test no duplicate sets.
+
+@pytest.fixture
+def pearl_backdoor_example_graph():
+    # TODO: Add reference to the book example.
+    graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
+                node[id "Z2" label "Z2"]
+                node[id "Z3" label "Z3"]
+                node[id "Z4" label "Z4"]
+                node[id "Z5" label "Z5"]
+                node[id "Z6" label "Z6"]
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]      
+                edge[source "Z1" target "Z3"]
+                edge[source "Z1" target "Z4"]
+                edge[source "Z2" target "Z4"]
+                edge[source "Z2" target "Z5"]
+                edge[source "Z3" target "X"]
+                edge[source "Z4" target "X"]
+                edge[source "Z4" target "Y"]
+                edge[source "Z5" target "Y"]
+                edge[source "Z6" target "Y"]
+                edge[source "X" target "Z6"]]    
+                """
+
+    graph = CausalGraph(
+            "X",
+            "Y",
+            graph_str,
+            observed_node_names=["Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "X", "Y"]
+    )
+    biased_backdoor_sets = [("Z4",), ("Z6",), ("Z5",), ("Z2",), ("Z1",), ("Z3",), ("Z1", "Z3"), ("Z2", "Z5"), ("Z1", "Z2")]
+    minimal_sufficient_adjustment_sets = [("Z1", "Z4"), ("Z2", "Z4"), ("Z3", "Z4"), ("Z5", "Z4")] 
+
+    return graph, biased_backdoor_sets, minimal_sufficient_adjustment_sets
+
+@pytest.fixture
+def simple_selection_bias_graph():
+    graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
+                    node[id "X" label "X"]
+                    node[id "Y" label "Y"]      
+                    edge[source "X" target "Y"]
+                    edge[source "X" target "Z1"]
+                    edge[source "Y" target "Z1"]]
+                    """
+
+    graph = CausalGraph(
+            "X",
+            "Y",
+            graph_str,
+            observed_node_names=["Z1", "X", "Y"]
+    )
+    biased_backdoor_sets = [("Z1",)] 
+    minimal_sufficient_adjustment_sets = []
+
+    return graph, biased_backdoor_sets, minimal_sufficient_adjustment_sets
+
+@pytest.fixture
+def simple_no_confounder_graph():
+    graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
+                node[id "X" label "X"]
+                node[id "Y" label "Y"]      
+                edge[source "X" target "Y"]
+                edge[source "Z1" target "X"]]
+                """
+
+    graph = CausalGraph(
+            "X",
+            "Y",
+            graph_str,
+            observed_node_names=["Z1", "X", "Y"]
+    )
+    biased_backdoor_sets = [] 
+    minimal_sufficient_adjustment_sets = []
+
+    return graph, biased_backdoor_sets, minimal_sufficient_adjustment_sets
+
+# See this discussion for details: https://github.com/pytest-dev/pytest/issues/349
+# Specifically, this solution: https://github.com/pytest-dev/pytest/issues/349#issuecomment-189370273.
+# getfixturevalue repleces getfuncargvalue as the latter is depracated.
+@pytest.fixture(params=["pearl_backdoor_example_graph", "simple_selection_bias_graph", "simple_no_confounder_graph"])
+def example_graph(request):
+    return request.getfixturevalue(request.param)
+
+class TestBackdoorIdentification(object):
+
+    def test_identify_backdoor_no_biased_sets(self, example_graph):
+        graph, biased_backdoor_sets, _ = example_graph
+        identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
+        
+        backdoor_results = identifier.identify_backdoor("X", "Y")
+        backdoor_sets = [
+            set(backdoor_result_dict["backdoor_set"]) 
+            for backdoor_result_dict in backdoor_results
+            if len(backdoor_result_dict["backdoor_set"]) > 0
+        ]
+
+        assert (
+            (len(backdoor_sets) == 0 and len(biased_backdoor_sets) == 0) # No biased sets exist and that's expected.
+            or  
+            all([
+                set(biased_backdoor_set) not in backdoor_sets 
+                for biased_backdoor_set in biased_backdoor_sets
+            ]) # No sets that would induce biased results are present in the solution.
+        )
+
+    def test_identify_backdoor_minimal_sufficient_adjustment_sets(self, example_graph):
+        graph, _, minimal_sufficient_adjustment_sets = example_graph
+        identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
+        
+        backdoor_results = identifier.identify_backdoor("X", "Y")
+        backdoor_sets = [
+            set(backdoor_result_dict["backdoor_set"]) 
+            for backdoor_result_dict in backdoor_results
+            if len(backdoor_result_dict["backdoor_set"]) > 0
+        ]
+
+        assert (
+            (len(backdoor_sets) == 0 and len(minimal_sufficient_adjustment_sets) == 0) # No adjustments needed and that's expected.
+            or
+            all([
+                set(minimal_sufficient_adjustment_set) in backdoor_sets 
+                for minimal_sufficient_adjustment_set in minimal_sufficient_adjustment_sets
+            ]) # The solution contains all the minimal sufficient adjustment sets.
+        )
+
+    

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -53,7 +53,7 @@ class TestBackdoorIdentification(object):
             set(backdoor_result_dict["backdoor_set"]) 
             for backdoor_result_dict in backdoor_results
         ]
-        print(backdoor_results)
+        
         assert (
             ((len(backdoor_sets) == 0) and (len(expected_sets) == 0)) # No adjustments exist and that's expected.
             or
@@ -83,17 +83,3 @@ class TestBackdoorIdentification(object):
                 for expected_set in expected_sets
             ])
         )
-
-    def test_identify_backdoor_adjustment_not_necessary(self, example_graph_solution: IdentificationTestGraphSolution):
-        graph = example_graph_solution.graph
-        adjustment_not_necessary = example_graph_solution.adjustment_not_necessary
-        identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search", proceed_when_unidentifiable=False)
-        
-        backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
-        res_adjustment_not_necessary = any([
-            len(backdoor_result_dict["backdoor_set"]) == 0 
-            for backdoor_result_dict in backdoor_results
-        ])
-
-        assert res_adjustment_not_necessary == adjustment_not_necessary
-    

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -2,96 +2,15 @@ import pytest
 from dowhy.causal_graph import CausalGraph
 from dowhy.causal_identifier import CausalIdentifier
 
-# TODO: What does num_paths_blocked_by_observed_nodes mean?
-# TODO: Test no duplicates in sets
-# TODO: Test no duplicate sets.
+from .base import IdentificationTestGraphSolution, example_graph_solution
 
-@pytest.fixture
-def pearl_backdoor_example_graph():
-    # TODO: Add reference to the book example.
-    graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
-                node[id "Z2" label "Z2"]
-                node[id "Z3" label "Z3"]
-                node[id "Z4" label "Z4"]
-                node[id "Z5" label "Z5"]
-                node[id "Z6" label "Z6"]
-                node[id "X" label "X"]
-                node[id "Y" label "Y"]      
-                edge[source "Z1" target "Z3"]
-                edge[source "Z1" target "Z4"]
-                edge[source "Z2" target "Z4"]
-                edge[source "Z2" target "Z5"]
-                edge[source "Z3" target "X"]
-                edge[source "Z4" target "X"]
-                edge[source "Z4" target "Y"]
-                edge[source "Z5" target "Y"]
-                edge[source "Z6" target "Y"]
-                edge[source "X" target "Z6"]]    
-                """
-
-    graph = CausalGraph(
-            "X",
-            "Y",
-            graph_str,
-            observed_node_names=["Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "X", "Y"]
-    )
-    biased_backdoor_sets = [("Z4",), ("Z6",), ("Z5",), ("Z2",), ("Z1",), ("Z3",), ("Z1", "Z3"), ("Z2", "Z5"), ("Z1", "Z2")]
-    minimal_sufficient_adjustment_sets = [("Z1", "Z4"), ("Z2", "Z4"), ("Z3", "Z4"), ("Z5", "Z4")] 
-
-    return graph, biased_backdoor_sets, minimal_sufficient_adjustment_sets
-
-@pytest.fixture
-def simple_selection_bias_graph():
-    graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
-                    node[id "X" label "X"]
-                    node[id "Y" label "Y"]      
-                    edge[source "X" target "Y"]
-                    edge[source "X" target "Z1"]
-                    edge[source "Y" target "Z1"]]
-                    """
-
-    graph = CausalGraph(
-            "X",
-            "Y",
-            graph_str,
-            observed_node_names=["Z1", "X", "Y"]
-    )
-    biased_backdoor_sets = [("Z1",)] 
-    minimal_sufficient_adjustment_sets = []
-
-    return graph, biased_backdoor_sets, minimal_sufficient_adjustment_sets
-
-@pytest.fixture
-def simple_no_confounder_graph():
-    graph_str = """graph[directed 1 node[id "Z1" label "Z1"]  
-                node[id "X" label "X"]
-                node[id "Y" label "Y"]      
-                edge[source "X" target "Y"]
-                edge[source "Z1" target "X"]]
-                """
-
-    graph = CausalGraph(
-            "X",
-            "Y",
-            graph_str,
-            observed_node_names=["Z1", "X", "Y"]
-    )
-    biased_backdoor_sets = [] 
-    minimal_sufficient_adjustment_sets = []
-
-    return graph, biased_backdoor_sets, minimal_sufficient_adjustment_sets
-
-# See this discussion for details: https://github.com/pytest-dev/pytest/issues/349
-# Specifically, this solution: https://github.com/pytest-dev/pytest/issues/349#issuecomment-189370273.
-# getfixturevalue repleces getfuncargvalue as the latter is depracated.
-@pytest.fixture(params=["pearl_backdoor_example_graph", "simple_selection_bias_graph", "simple_no_confounder_graph"])
-def example_graph(request):
-    return request.getfixturevalue(request.param)
+# TODO: How to differentiate when no adjustment is needed from when no adjustment exists?
 
 class TestBackdoorIdentification(object):
 
-    def test_identify_backdoor_no_biased_sets(self, example_graph):
-        graph, biased_backdoor_sets, _ = example_graph
+    def test_identify_backdoor_no_biased_sets(self, example_graph_solution: IdentificationTestGraphSolution):
+        graph = example_graph_solution.graph
+        biased_sets = example_graph_solution.biased_sets
         identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
         
         backdoor_results = identifier.identify_backdoor("X", "Y")
@@ -102,17 +21,32 @@ class TestBackdoorIdentification(object):
         ]
 
         assert (
-            (len(backdoor_sets) == 0 and len(biased_backdoor_sets) == 0) # No biased sets exist and that's expected.
+            (len(backdoor_sets) == 0 and len(biased_sets) == 0) # No biased sets exist and that's expected.
             or  
             all([
                 set(biased_backdoor_set) not in backdoor_sets 
-                for biased_backdoor_set in biased_backdoor_sets
+                for biased_backdoor_set in biased_sets
             ]) # No sets that would induce biased results are present in the solution.
         )
 
-    def test_identify_backdoor_minimal_sufficient_adjustment_sets(self, example_graph):
-        graph, _, minimal_sufficient_adjustment_sets = example_graph
+    def test_identify_backdoor_unobserved_not_in_backdoor_set(self, example_graph_solution: IdentificationTestGraphSolution):
+        graph = example_graph_solution.graph
+        observed_variables = example_graph_solution.observed_variables
         identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
+
+        backdoor_results = identifier.identify_backdoor("X", "Y")
+        backdoor_sets = [
+            set(backdoor_result_dict["backdoor_set"]) 
+            for backdoor_result_dict in backdoor_results
+            if len(backdoor_result_dict["backdoor_set"]) > 0
+        ]
+
+        assert all([variable in observed_variables for backdoor_set in backdoor_sets for variable in backdoor_set]) # All variables used in the backdoor sets must be observed.
+
+    def test_identify_backdoor_expected_sets(self, example_graph_solution: IdentificationTestGraphSolution):
+        graph = example_graph_solution.graph
+        expected_sets = example_graph_solution.expected_sets
+        identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search", proceed_when_unidentifiable=False)
         
         backdoor_results = identifier.identify_backdoor("X", "Y")
         backdoor_sets = [
@@ -122,11 +56,11 @@ class TestBackdoorIdentification(object):
         ]
 
         assert (
-            (len(backdoor_sets) == 0 and len(minimal_sufficient_adjustment_sets) == 0) # No adjustments needed and that's expected.
+            ((len(backdoor_sets) == 0) and (len(expected_sets) == 0)) # No adjustments needed and that's expected.
             or
             all([
-                set(minimal_sufficient_adjustment_set) in backdoor_sets 
-                for minimal_sufficient_adjustment_set in minimal_sufficient_adjustment_sets
+                set(expected_set) in backdoor_sets 
+                for expected_set in expected_sets
             ]) # The solution contains all the minimal sufficient adjustment sets.
         )
 

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -5,7 +5,6 @@ from dowhy.causal_identifier import CausalIdentifier
 from .base import IdentificationTestGraphSolution, example_graph_solution
 
 
-# TODO: How to differentiate when no adjustment is needed from when no adjustment exists?
 class TestBackdoorIdentification(object):
 
     def test_identify_backdoor_no_biased_sets(self, example_graph_solution: IdentificationTestGraphSolution):

--- a/tests/causal_identifiers/test_backdoor_identifier.py
+++ b/tests/causal_identifiers/test_backdoor_identifier.py
@@ -13,7 +13,7 @@ class TestBackdoorIdentification(object):
         biased_sets = example_graph_solution.biased_sets
         identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
         
-        backdoor_results = identifier.identify_backdoor("X", "Y")
+        backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
         backdoor_sets = [
             set(backdoor_result_dict["backdoor_set"]) 
             for backdoor_result_dict in backdoor_results
@@ -34,7 +34,7 @@ class TestBackdoorIdentification(object):
         observed_variables = example_graph_solution.observed_variables
         identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search")
 
-        backdoor_results = identifier.identify_backdoor("X", "Y")
+        backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
         backdoor_sets = [
             set(backdoor_result_dict["backdoor_set"]) 
             for backdoor_result_dict in backdoor_results
@@ -48,7 +48,7 @@ class TestBackdoorIdentification(object):
         expected_sets = example_graph_solution.expected_sets
         identifier = CausalIdentifier(graph, "nonparametric-ate", method_name="exhaustive-search", proceed_when_unidentifiable=False)
         
-        backdoor_results = identifier.identify_backdoor("X", "Y")
+        backdoor_results = identifier.identify_backdoor("X", "Y", include_unobserved=False)
         backdoor_sets = [
             set(backdoor_result_dict["backdoor_set"]) 
             for backdoor_result_dict in backdoor_results

--- a/tests/causal_refuters/base.py
+++ b/tests/causal_refuters/base.py
@@ -1,6 +1,8 @@
+import logging
+
 import dowhy.datasets
 from dowhy import CausalModel
-import logging
+
 
 class TestRefuter(object):
     def __init__(self, error_tolerance, estimator_method, refuter_method,
@@ -42,7 +44,7 @@ class TestRefuter(object):
             proceed_when_unidentifiable=True,
             test_significance=None
         )
-        target_estimand = model.identify_effect()
+        target_estimand = model.identify_effect(method_name="exhaustive-search")
         target_estimand.set_identifier_method(self.identifier_method)
         ate_estimate = model.estimate_effect(
             identified_estimand=target_estimand,


### PR DESCRIPTION
The PR contains first batch of tests for the backdoor identification



At the moment, the method being tested is [CausalIdentifier.identify_backdoor](https://github.com/vojavocni/dowhy/blob/2970c7edddbc13dce267dc7b59a68aac0fe4a34e/dowhy/causal_identifier.py#L236).

From my perspective, this function should:

1. not return unobserved variables in backdoor sets
2. not return adjustment sets that induce bias
3. return all expected adjustment sets, at least the minimum sufficient adjustment sets 

TODO:

- [x] Ensure the expected output is clear. This requires small refactoring in identify_backdoor.
- [x] Ensure nothing is returned if no adjustment is needed.
- [x] Ensure all tests are correct and that they pass.
- [x] Maximal-adjustment set as the default method
- [x] Backdoor set with minimum number of IVs is selected as default in `get_default_backdoor_set_id`


Three tests fail at the moment, one of them related to problems 1. and 2. and should be fixed by some refactoring of identify backdoor to not include unobserved variables and not adjust if there is no need.

The other two are related to this graph:

![image](https://user-images.githubusercontent.com/40206443/110355625-1f85ee80-8042-11eb-9eb5-5befe7bba919.png)


The possible adjustment sets are: (C), (B,C) and (B,A). The path X <- B <- C -> Y needs to be closed. The easiest way to do it is to adjust for C, and the test passes here.

In first of them, all variables are observed, but (B,A) is not returned as one of the possible adjustments sets. This is not that terrible, as C is detected, but it should probably still be there.

In the second of them, C is unobserved, so (B,A) is the only adjustment set possible, but it's not returned.
So these two are very similar (at least the core issue is the same). I believe this is a bug and will require a bit more detective work.



