### PR TITLE
Added size and file_name parameters to view_model

### DIFF
--- a/dowhy/causal_graph.py
+++ b/dowhy/causal_graph.py
@@ -79,17 +79,18 @@ class CausalGraph:
         # Adding node attributes
         self._graph = self.add_node_attributes(observed_node_names)
 
-    def view_graph(self, layout="dot"):
-        out_filename = "causal_model.png"
+    def view_graph(self, layout="dot", size=(8, 6), file_name="causal_model"):
+        out_filename = "{}.png".format(file_name)
         try:
             import pygraphviz as pgv
             agraph = nx.drawing.nx_agraph.to_agraph(self._graph)
+            agraph.graph_attr.update(size="{},{}!".format(size[0], size[0]))
             agraph.draw(out_filename, format="png", prog=layout)
         except:
             self.logger.warning("Warning: Pygraphviz cannot be loaded. Check that graphviz and pygraphviz are installed.")
             self.logger.info("Using Matplotlib for plotting")
             import matplotlib.pyplot as plt
-
+            plt.figure(figsize=size)
             solid_edges = [(n1,n2) for n1,n2, e in self._graph.edges(data=True) if 'style' not in e ]
             dashed_edges =[(n1,n2) for n1,n2, e in self._graph.edges(data=True) if ('style' in e and e['style']=="dashed") ]
             plt.clf()

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -322,6 +322,8 @@ class CausalModel:
         """View the causal DAG.
 
         :param layout: string specifying the layout of the graph.
+        :param size: tuple (x, y) specifying the width and height of the figure in inches.
+        :param file_name: string specifying the file name for the saved causal graph png.
 
         :returns: a visualization of the graph
 

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -318,7 +318,7 @@ class CausalModel:
         res = refuter.refute_estimate()
         return res
 
-    def view_model(self, layout="dot"):
+    def view_model(self, layout="dot", size=(8, 6), file_name="causal_model"):
         """View the causal DAG.
 
         :param layout: string specifying the layout of the graph.
@@ -326,7 +326,7 @@ class CausalModel:
         :returns: a visualization of the graph
 
         """
-        self._graph.view_graph(layout)
+        self._graph.view_graph(layout, size, file_name)
 
     def interpret(self, method_name=None, **kwargs):
         """Interpret the causal model.


### PR DESCRIPTION
As requested by sai_ on the discord server, it would be useful to be able to specify the size and file name of the figure produced by view_model.

I have added two parameters to view_model: `size` and `file_name`.

`size` allows the user to specify the desired size of the figure as a tuple `(x, y)` where `x` and `y` are the width and height in inches. This is consistent with the `figsize` argument in matplotlib. I have also ensured that this works with both matplotlib and pygraphviz.

`file_name` allows the user to specify the desired name of the png image (without including the `.png` extension). 

Example:
` model.view_model(layout="dot", size=(100, 20), file_name="my_causal_model")`