### PR TITLE
Pin networkx upper bound to avoid installtion of matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.15
 scipy
 statsmodels
 pandas>=0.24
-networkx>=2.0
+networkx>=2.0,<=2.5
 sympy>=1.4
 scikit-learn
 pydot>=1.4


### PR DESCRIPTION
It seems new release of networkx brings in matplotlib, hence pinning the upper bound.