### PR TITLE
Added support for custom propensity models

### DIFF
--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -4,12 +4,24 @@ import pandas as pd
 from dowhy.causal_estimator import CausalEstimator
 
 class PropensityScoreEstimator(CausalEstimator):
-
-    def __init__(self, *args, **kwargs):
+    """ 
+    Base class for estimators that estimate effects based on propensity of treatment assignment.
+    Supports additional parameters that can be specified in the estimate_effect() method.
+    - 'propensity_score_model': The model used to compute propensity score. Could be any classification model that supports fit() and predict_proba() methods. If None, use LogisticRegression model as the default. Default=None
+    - 'recalculate_propensity_score': If true, force the estimator to calculate the propensity score. To use pre-computed propensity score, set this value to false. Default=True
+    - 'propensity_score_column': column name that stores the propensity score. Default='propensity_score'
+    """
+    def __init__(self, *args, propensity_score_model=None, recalculate_propensity_score=True, propensity_score_column="propensity_score", **kwargs):
         super().__init__(*args, **kwargs)
 
-        # We need to initialize the model when we create any propensity score estimator
-        self._propensity_score_model = None
+        # Enable the user to pass params for a custom propensity model
+        if not hasattr(self, "propensity_score_model"):
+            self.propensity_score_model = propensity_score_model
+        if not hasattr(self, "recalculate_propensity_score"):
+            self.recalculate_propensity_score = recalculate_propensity_score
+        if not hasattr(self, "propensity_score_column"):
+            self.propensity_score_column = propensity_score_column
+
         # Check if the treatment is one-dimensional
         if len(self._treatment_name) > 1:
             error_msg = str(self.__class__) + "cannot handle more than one treatment variable"
@@ -45,14 +57,10 @@ class PropensityScoreEstimator(CausalEstimator):
         '''
         raise NotImplementedError
 
-    def _estimate_effect(self, recalculate_propensity_score=False):
+    def _estimate_effect(self):
         '''
             A custom estimator based on the way the propensity score estimates are to be used.
-            
-            Parameters
-            -----------
-            recalculate_propensity_score: bool, default False,
-            This forces the estimator to recalculate the estimate for the propensity score.
+
         '''
         raise NotImplementedError
 

--- a/dowhy/causal_estimators/propensity_score_matching_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_matching_estimator.py
@@ -6,9 +6,30 @@ from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimators.propensity_score_estimator import PropensityScoreEstimator
 
 class PropensityScoreMatchingEstimator(PropensityScoreEstimator):
+    """ Estimate effect of treatment by finding matching treated and control units based on propensity score.
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    Straightforward application of the back-door criterion.
+
+    Supports additional parameters that can be specified in the estimate_effect() method.
+
+    - 'propensity_score_model': The model used to compute propensity score. Could be any classification model that supports fit() and predict_proba() methods. If None, use LogisticRegression model as the default. Default=None
+    - 'recalculate_propensity_score': If true, force the estimator to calculate the propensity score. To use pre-computed propensity score, set this value to false. Default=True
+    - 'propensity_score_column': column name that stores the propensity score. Default='propensity_score'
+
+    """
+    def __init__(
+        self, 
+        *args, 
+        propensity_score_model=None, 
+        recalculate_propensity_score=True, 
+        propensity_score_column="propensity_score",
+        **kwargs):
+        super().__init__(
+            *args, 
+            propensity_score_model=propensity_score_model,
+            recalculate_propensity_score=recalculate_propensity_score,
+            propensity_score_column=propensity_score_column,
+            **kwargs)
 
         self.logger.info("INFO: Using Propensity Score Matching Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)

--- a/dowhy/causal_estimators/propensity_score_stratification_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_stratification_estimator.py
@@ -24,16 +24,23 @@ class PropensityScoreStratificationEstimator(PropensityScoreEstimator):
             self.clipping_threshold = clipping_threshold
 
     def _estimate_effect(self, recalculate_propensity_score=False):
-        if self._propensity_score_model is None or recalculate_propensity_score is True:
-            self._propensity_score_model = linear_model.LogisticRegression()
-            self._propensity_score_model.fit(self._observed_common_causes, self._treatment)
-            self._data['propensity_score'] = self._propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
+        if self.recalculate_propensity_score is True:
+            if self.propensity_score_model is None:
+                self.propensity_score_model = linear_model.LogisticRegression()
+            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
+            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
+        else:
+            # check if the user provides the propensity score column
+            if self.propensity_score_column not in self._data.columns:
+                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
+            else:
+                self.logger.info(f"INFO: Using pre-computed propensity score incolumn {self.propensity_score_column}")
 
         # sort the dataframe by propensity score
         # create a column 'strata' for each element that marks what strata it belongs to
         num_rows = self._data[self._outcome_name].shape[0]
         self._data['strata'] = (
-            (self._data['propensity_score'].rank(ascending=True) / num_rows) * self.num_strata
+            (self._data[self.propensity_score_column].rank(ascending=True) / num_rows) * self.num_strata
         ).round(0)
         # for each strata, count how many treated and control units there are
         # throw away strata that have insufficient treatment or control
@@ -86,7 +93,7 @@ class PropensityScoreStratificationEstimator(PropensityScoreEstimator):
                                   treatment_value=self._treatment_value,
                                   target_estimand=self._target_estimand,
                                   realized_estimand_expr=self.symbolic_estimator,
-                                  propensity_scores = self._data["propensity_score"])
+                                  propensity_scores = self._data[self.propensity_score_column])
         return estimate
 
     def construct_symbolic_estimator(self, estimand):

--- a/dowhy/causal_estimators/propensity_score_stratification_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_stratification_estimator.py
@@ -23,7 +23,7 @@ class PropensityScoreStratificationEstimator(PropensityScoreEstimator):
         if not hasattr(self, 'clipping_threshold'):
             self.clipping_threshold = clipping_threshold
 
-    def _estimate_effect(self, recalculate_propensity_score=False):
+    def _estimate_effect(self):
         if self.recalculate_propensity_score is True:
             if self.propensity_score_model is None:
                 self.propensity_score_model = linear_model.LogisticRegression()

--- a/dowhy/causal_estimators/propensity_score_stratification_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_stratification_estimator.py
@@ -10,10 +10,32 @@ class PropensityScoreStratificationEstimator(PropensityScoreEstimator):
     identical common causes.
 
     Straightforward application of the back-door criterion.
+
+    Supports additional parameters that can be specified in the estimate_effect() method.
+
+    - 'num_strata': Number of bins by which data will be stratified. Default=50
+    - 'clipping_threshold': Mininum number of treated or control units per strata. Default=10
+    - 'propensity_score_model': The model used to compute propensity score. Could be any classification model that supports fit() and predict_proba() methods. If None, use LogisticRegression model as the default. Default=None
+    - 'recalculate_propensity_score': If true, force the estimator to calculate the propensity score. To use pre-computed propensity score, set this value to false. Default=True
+    - 'propensity_score_column': column name that stores the propensity score. Default='propensity_score'
+
     """
 
-    def __init__(self, *args, num_strata=50, clipping_threshold=10, **kwargs):
-        super().__init__(*args,  **kwargs)
+    def __init__(
+        self, 
+        *args, 
+        num_strata=50, 
+        clipping_threshold=10, 
+        propensity_score_model=None, 
+        recalculate_propensity_score=True, 
+        propensity_score_column="propensity_score",
+        **kwargs):
+        super().__init__(
+            *args, 
+            propensity_score_model=propensity_score_model,
+            recalculate_propensity_score=recalculate_propensity_score,
+            propensity_score_column=propensity_score_column, 
+            **kwargs)
 
         self.logger.info("INFO: Using Propensity Score Stratification Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -14,69 +14,80 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
     Supports additional parameters that can be specified in the estimate_effect() method.
 
     - 'weighting_scheme': This is the name of weighting method to use. Can be inverse propensity score ("ips_weight", default), stabilized IPS score ("ips_stabilized_weight"), or normalized IPS score ("ips_normalized_weight")
+    - 'min_ps_score': Lower bound used to clip the propensity score. Default value = 0.05
+    - 'max_ps_score': Upper bound used to clip the propensity score. Default value = 0.95
 
     """
 
-    def __init__(self, *args, min_ps_score=0.05, max_ps_score=0.95, **kwargs):
+    def __init__(self, *args, min_ps_score=0.05, max_ps_score=0.95, weighting_scheme='ips_weight', **kwargs):
         super().__init__(*args, **kwargs)
 
         self.logger.info("INFO: Using Propensity Score Weighting Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
         self.logger.info(self.symbolic_estimator)
         if not hasattr(self, "weighting_scheme"):
-            self.weighting_scheme = 'ips_weight'  # 'ips_weight', 'ips_normalized_weight', 'ips_stabilized_weight'
-        self.min_ps_score = min_ps_score
-        self.max_ps_score = max_ps_score
+            self.weighting_scheme = weighting_scheme  # 'ips_weight', 'ips_normalized_weight', 'ips_stabilized_weight'
+        if not hasattr(self, "min_ps_score"):
+            self.min_ps_score = min_ps_score
+        if not hasattr(self, "max_ps_score"):
+            self.max_ps_score = max_ps_score
 
     def _estimate_effect(self, recalculate_propensity_score=False):
-        if self._propensity_score_model is None or recalculate_propensity_score is True:
-            self._propensity_score_model = linear_model.LogisticRegression()
-            self._propensity_score_model.fit(self._observed_common_causes, self._treatment)
-            self._data['ps'] = self._propensity_score_model.predict_proba(self._observed_common_causes)[:,1]
+        if self.recalculate_propensity_score is True:
+            if self.propensity_score_model is None:
+                self.propensity_score_model = linear_model.LogisticRegression()
+            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
+            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
+        else:
+            # check if user provides the propensity score column
+            if self.propensity_score_column not in self._data.columns:
+                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
+            else:
+                self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
 
         # trim propensity score weights
-        self._data['ps'] = np.minimum(self.max_ps_score, self._data['ps'])
-        self._data['ps'] = np.maximum(self.min_ps_score, self._data['ps'])
+        self._data[self.propensity_score_column] = np.minimum(self.max_ps_score, self._data[self.propensity_score_column])
+        self._data[self.propensity_score_column] = np.maximum(self.min_ps_score, self._data[self.propensity_score_column])
 
         # ips ==> (isTreated(y)/ps(y)) + ((1-isTreated(y))/(1-ps(y)))
         # nips ==> ips / (sum of ips over all units)
         # icps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all control units)
         # itps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all treatment units)
-        ipst_sum = sum(self._data[self._treatment_name[0]] / self._data['ps'])
-        ipsc_sum = sum((1 - self._data[self._treatment_name[0]]) / (1-self._data['ps']))
+        ipst_sum = sum(self._data[self._treatment_name[0]] / self._data[self.propensity_score_column])
+        ipsc_sum = sum((1 - self._data[self._treatment_name[0]]) / (1-self._data[self.propensity_score_column]))
         num_units = len(self._data[self._treatment_name[0]])
         num_treatment_units = sum(self._data[self._treatment_name[0]])
         num_control_units = num_units - num_treatment_units
 
         # Vanilla IPS estimator
         self._data['ips_weight'] = (
-            self._data[self._treatment_name[0]] / self._data['ps'] +
-            (1 - self._data[self._treatment_name[0]]) / (1 - self._data['ps'])
+            self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] +
+            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column])
         )
         self._data['tips_weight'] = (
             self._data[self._treatment_name[0]] +
-            (1 - self._data[self._treatment_name[0]]) * self._data['ps']/ (1 - self._data['ps'])
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column]/ (1 - self._data[self.propensity_score_column])
         )
         self._data['cips_weight'] = (
-            self._data[self._treatment_name[0]] * (1 - self._data['ps'])/ self._data['ps'] +
+            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column])/ self._data[self.propensity_score_column] +
             (1 - self._data[self._treatment_name[0]])
         )
 
         # The Hajek estimator (or the self-normalized estimator)
         self._data['ips_normalized_weight'] = (
-            self._data[self._treatment_name[0]] / self._data['ps'] / ipst_sum +
-            (1 - self._data[self._treatment_name[0]]) / (1 - self._data['ps']) / ipsc_sum
+            self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] / ipst_sum +
+            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column]) / ipsc_sum
         )
         ipst_for_att_sum = sum(self._data[self._treatment_name[0]])
-        ipsc_for_att_sum = sum((1-self._data[self._treatment_name[0]])/(1 - self._data['ps'])*self._data['ps'] )
+        ipsc_for_att_sum = sum((1-self._data[self._treatment_name[0]])/(1 - self._data[self.propensity_score_column])*self._data[self.propensity_score_column] )
         self._data['tips_normalized_weight'] = (
             self._data[self._treatment_name[0]]/ ipst_for_att_sum  +
-            (1 - self._data[self._treatment_name[0]]) * self._data['ps'] / (1 - self._data['ps']) / ipsc_for_att_sum
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column]) / ipsc_for_att_sum
         )
-        ipst_for_atc_sum = sum(self._data[self._treatment_name[0]] / self._data['ps'] * (1-self._data['ps']))
+        ipst_for_atc_sum = sum(self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] * (1-self._data[self.propensity_score_column]))
         ipsc_for_atc_sum = sum((1 - self._data[self._treatment_name[0]]))
         self._data['cips_normalized_weight'] = (
-            self._data[self._treatment_name[0]] * (1 - self._data['ps']) / self._data['ps'] / ipst_for_atc_sum +
+            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] / ipst_for_atc_sum +
             (1 - self._data[self._treatment_name[0]])/ipsc_for_atc_sum
         )
 
@@ -84,15 +95,15 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         # Paper: Marginal Structural Models and Causal Inference in Epidemiology
         p_treatment = sum(self._data[self._treatment_name[0]])/num_units
         self._data['ips_stabilized_weight'] = (
-            self._data[self._treatment_name[0]] / self._data['ps'] * p_treatment +
-            (1 - self._data[self._treatment_name[0]]) / (1 - self._data['ps']) * (1- p_treatment)
+            self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] * p_treatment +
+            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column]) * (1- p_treatment)
         )
         self._data['tips_stabilized_weight'] = (
             self._data[self._treatment_name[0]] * p_treatment  +
-            (1 - self._data[self._treatment_name[0]]) * self._data['ps'] / (1 - self._data['ps']) * (1- p_treatment)
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column]) * (1- p_treatment)
         )
         self._data['cips_stabilized_weight'] = (
-            self._data[self._treatment_name[0]] * (1 - self._data['ps']) / self._data['ps'] * p_treatment +
+            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] * p_treatment +
             (1 - self._data[self._treatment_name[0]])* (1-p_treatment)
         )
 
@@ -130,7 +141,7 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
                                   treatment_value=self._treatment_value,
                                   target_estimand=self._target_estimand,
                                   realized_estimand_expr=self.symbolic_estimator,
-                                  propensity_scores = self._data["ps"])
+                                  propensity_scores = self._data[self.propensity_score_column])
         return estimate
 
     def construct_symbolic_estimator(self, estimand):

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -14,14 +14,31 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
 
     Supports additional parameters that can be specified in the estimate_effect() method.
 
+    - 'min_ps_score': Lower bound used to clip the propensity score. Default=0.05
+    - 'max_ps_score': Upper bound used to clip the propensity score. Default=0.95
     - 'weighting_scheme': This is the name of weighting method to use. Can be inverse propensity score ("ips_weight", default), stabilized IPS score ("ips_stabilized_weight"), or normalized IPS score ("ips_normalized_weight")
-    - 'min_ps_score': Lower bound used to clip the propensity score. Default value = 0.05
-    - 'max_ps_score': Upper bound used to clip the propensity score. Default value = 0.95
+    - 'propensity_score_model': The model used to compute propensity score. Could be any classification model that supports fit() and predict_proba() methods. If None, use LogisticRegression model as the default. Default=None
+    - 'recalculate_propensity_score': If true, force the estimator to calculate the propensity score. To use pre-computed propensity score, set this value to false. Default=True
+    - 'propensity_score_column': column name that stores the propensity score. Default='propensity_score'
 
     """
 
-    def __init__(self, *args, min_ps_score=0.05, max_ps_score=0.95, weighting_scheme='ips_weight', **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, 
+        *args, 
+        min_ps_score=0.05, 
+        max_ps_score=0.95, 
+        weighting_scheme='ips_weight', 
+        propensity_score_model=None, 
+        recalculate_propensity_score=True, 
+        propensity_score_column="propensity_score",
+        **kwargs):
+        super().__init__(
+            *args, 
+            propensity_score_model=propensity_score_model,
+            recalculate_propensity_score=recalculate_propensity_score,
+            propensity_score_column=propensity_score_column,
+            **kwargs)
 
         self.logger.info("INFO: Using Propensity Score Weighting Estimator")
         self.symbolic_estimator = self.construct_symbolic_estimator(

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -5,6 +5,7 @@ from sklearn import linear_model
 from dowhy.causal_estimator import CausalEstimate
 from dowhy.causal_estimators.propensity_score_estimator import PropensityScoreEstimator
 
+
 class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
     """ Estimate effect of treatment by weighing the data by
     inverse probability of occurrence.
@@ -23,38 +24,48 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         super().__init__(*args, **kwargs)
 
         self.logger.info("INFO: Using Propensity Score Weighting Estimator")
-        self.symbolic_estimator = self.construct_symbolic_estimator(self._target_estimand)
+        self.symbolic_estimator = self.construct_symbolic_estimator(
+            self._target_estimand)
         self.logger.info(self.symbolic_estimator)
         if not hasattr(self, "weighting_scheme"):
-            self.weighting_scheme = weighting_scheme  # 'ips_weight', 'ips_normalized_weight', 'ips_stabilized_weight'
+            # 'ips_weight', 'ips_normalized_weight', 'ips_stabilized_weight'
+            self.weighting_scheme = weighting_scheme
         if not hasattr(self, "min_ps_score"):
             self.min_ps_score = min_ps_score
         if not hasattr(self, "max_ps_score"):
             self.max_ps_score = max_ps_score
 
-    def _estimate_effect(self, recalculate_propensity_score=False):
+    def _estimate_effect(self):
         if self.recalculate_propensity_score is True:
             if self.propensity_score_model is None:
                 self.propensity_score_model = linear_model.LogisticRegression()
-            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
-            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
+            self.propensity_score_model.fit(
+                self._observed_common_causes, self._treatment)
+            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(
+                self._observed_common_causes)[:, 1]
         else:
             # check if user provides the propensity score column
             if self.propensity_score_column not in self._data.columns:
-                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
+                raise ValueError(
+                    f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
             else:
-                self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
+                self.logger.info(
+                    f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
 
         # trim propensity score weights
-        self._data[self.propensity_score_column] = np.minimum(self.max_ps_score, self._data[self.propensity_score_column])
-        self._data[self.propensity_score_column] = np.maximum(self.min_ps_score, self._data[self.propensity_score_column])
+        self._data[self.propensity_score_column] = np.minimum(
+            self.max_ps_score, self._data[self.propensity_score_column])
+        self._data[self.propensity_score_column] = np.maximum(
+            self.min_ps_score, self._data[self.propensity_score_column])
 
         # ips ==> (isTreated(y)/ps(y)) + ((1-isTreated(y))/(1-ps(y)))
         # nips ==> ips / (sum of ips over all units)
         # icps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all control units)
         # itps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all treatment units)
-        ipst_sum = sum(self._data[self._treatment_name[0]] / self._data[self.propensity_score_column])
-        ipsc_sum = sum((1 - self._data[self._treatment_name[0]]) / (1-self._data[self.propensity_score_column]))
+        ipst_sum = sum(self._data[self._treatment_name[0]] /
+                       self._data[self.propensity_score_column])
+        ipsc_sum = sum((1 - self._data[self._treatment_name[0]]) /
+                       (1-self._data[self.propensity_score_column]))
         num_units = len(self._data[self._treatment_name[0]])
         num_treatment_units = sum(self._data[self._treatment_name[0]])
         num_control_units = num_units - num_treatment_units
@@ -62,29 +73,35 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         # Vanilla IPS estimator
         self._data['ips_weight'] = (
             self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] +
-            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column])
+            (1 - self._data[self._treatment_name[0]]) /
+            (1 - self._data[self.propensity_score_column])
         )
         self._data['tips_weight'] = (
             self._data[self._treatment_name[0]] +
-            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column]/ (1 - self._data[self.propensity_score_column])
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (
+                1 - self._data[self.propensity_score_column])
         )
         self._data['cips_weight'] = (
-            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column])/ self._data[self.propensity_score_column] +
+            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] +
             (1 - self._data[self._treatment_name[0]])
         )
 
         # The Hajek estimator (or the self-normalized estimator)
         self._data['ips_normalized_weight'] = (
             self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] / ipst_sum +
-            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column]) / ipsc_sum
+            (1 - self._data[self._treatment_name[0]]) / (1 -
+                                                         self._data[self.propensity_score_column]) / ipsc_sum
         )
         ipst_for_att_sum = sum(self._data[self._treatment_name[0]])
-        ipsc_for_att_sum = sum((1-self._data[self._treatment_name[0]])/(1 - self._data[self.propensity_score_column])*self._data[self.propensity_score_column] )
+        ipsc_for_att_sum = sum((1-self._data[self._treatment_name[0]])/(
+            1 - self._data[self.propensity_score_column])*self._data[self.propensity_score_column])
         self._data['tips_normalized_weight'] = (
-            self._data[self._treatment_name[0]]/ ipst_for_att_sum  +
-            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column]) / ipsc_for_att_sum
+            self._data[self._treatment_name[0]] / ipst_for_att_sum +
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (
+                1 - self._data[self.propensity_score_column]) / ipsc_for_att_sum
         )
-        ipst_for_atc_sum = sum(self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] * (1-self._data[self.propensity_score_column]))
+        ipst_for_atc_sum = sum(self._data[self._treatment_name[0]] /
+                               self._data[self.propensity_score_column] * (1-self._data[self.propensity_score_column]))
         ipsc_for_atc_sum = sum((1 - self._data[self._treatment_name[0]]))
         self._data['cips_normalized_weight'] = (
             self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] / ipst_for_atc_sum +
@@ -96,15 +113,17 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         p_treatment = sum(self._data[self._treatment_name[0]])/num_units
         self._data['ips_stabilized_weight'] = (
             self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] * p_treatment +
-            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column]) * (1- p_treatment)
+            (1 - self._data[self._treatment_name[0]]) / (1 -
+                                                         self._data[self.propensity_score_column]) * (1 - p_treatment)
         )
         self._data['tips_stabilized_weight'] = (
-            self._data[self._treatment_name[0]] * p_treatment  +
-            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column]) * (1- p_treatment)
+            self._data[self._treatment_name[0]] * p_treatment +
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (
+                1 - self._data[self.propensity_score_column]) * (1 - p_treatment)
         )
         self._data['cips_stabilized_weight'] = (
             self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] * p_treatment +
-            (1 - self._data[self._treatment_name[0]])* (1-p_treatment)
+            (1 - self._data[self._treatment_name[0]]) * (1-p_treatment)
         )
 
         if self._target_units == "ate":
@@ -128,12 +147,12 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
             self._data[self._outcome_name]
         )
         sum_dy_weights = np.sum(
-                self._data[self._treatment_name[0]] * self._data[weighting_scheme_name])
+            self._data[self._treatment_name[0]] * self._data[weighting_scheme_name])
         sum_dbary_weights = np.sum(
-                (1 - self._data[self._treatment_name[0]]) * self._data[weighting_scheme_name])
+            (1 - self._data[self._treatment_name[0]]) * self._data[weighting_scheme_name])
         # Subtracting the weighted means
-        est = self._data['d_y'].sum() / sum_dy_weights - self._data['dbar_y'].sum() / sum_dbary_weights
-
+        est = self._data['d_y'].sum() / sum_dy_weights - \
+            self._data['dbar_y'].sum() / sum_dbary_weights
 
         # TODO - how can we add additional information into the returned estimate?
         estimate = CausalEstimate(estimate=est,
@@ -141,7 +160,7 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
                                   treatment_value=self._treatment_value,
                                   target_estimand=self._target_estimand,
                                   realized_estimand_expr=self.symbolic_estimator,
-                                  propensity_scores = self._data[self.propensity_score_column])
+                                  propensity_scores=self._data[self.propensity_score_column])
         return estimate
 
     def construct_symbolic_estimator(self, estimand):

--- a/dowhy/causal_estimators/propensity_score_weighting_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_weighting_estimator.py
@@ -56,33 +56,25 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         if self.recalculate_propensity_score is True:
             if self.propensity_score_model is None:
                 self.propensity_score_model = linear_model.LogisticRegression()
-            self.propensity_score_model.fit(
-                self._observed_common_causes, self._treatment)
-            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(
-                self._observed_common_causes)[:, 1]
+            self.propensity_score_model.fit(self._observed_common_causes, self._treatment)
+            self._data[self.propensity_score_column] = self.propensity_score_model.predict_proba(self._observed_common_causes)[:, 1]
         else:
             # check if user provides the propensity score column
             if self.propensity_score_column not in self._data.columns:
-                raise ValueError(
-                    f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
+                raise ValueError(f"Propensity score column {self.propensity_score_column} does not exist. Please specify the column name that has your pre-computed propensity score.")
             else:
-                self.logger.info(
-                    f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
+                self.logger.info(f"INFO: Using pre-computed propensity score in column {self.propensity_score_column}")
 
         # trim propensity score weights
-        self._data[self.propensity_score_column] = np.minimum(
-            self.max_ps_score, self._data[self.propensity_score_column])
-        self._data[self.propensity_score_column] = np.maximum(
-            self.min_ps_score, self._data[self.propensity_score_column])
+        self._data[self.propensity_score_column] = np.minimum(self.max_ps_score, self._data[self.propensity_score_column])
+        self._data[self.propensity_score_column] = np.maximum(self.min_ps_score, self._data[self.propensity_score_column])
 
         # ips ==> (isTreated(y)/ps(y)) + ((1-isTreated(y))/(1-ps(y)))
         # nips ==> ips / (sum of ips over all units)
         # icps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all control units)
         # itps ==> ps(y)/(1-ps(y)) / (sum of (ps(y)/(1-ps(y))) over all treatment units)
-        ipst_sum = sum(self._data[self._treatment_name[0]] /
-                       self._data[self.propensity_score_column])
-        ipsc_sum = sum((1 - self._data[self._treatment_name[0]]) /
-                       (1-self._data[self.propensity_score_column]))
+        ipst_sum = sum(self._data[self._treatment_name[0]] / self._data[self.propensity_score_column])
+        ipsc_sum = sum((1 - self._data[self._treatment_name[0]]) / (1-self._data[self.propensity_score_column]))
         num_units = len(self._data[self._treatment_name[0]])
         num_treatment_units = sum(self._data[self._treatment_name[0]])
         num_control_units = num_units - num_treatment_units
@@ -90,35 +82,28 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         # Vanilla IPS estimator
         self._data['ips_weight'] = (
             self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] +
-            (1 - self._data[self._treatment_name[0]]) /
-            (1 - self._data[self.propensity_score_column])
+            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column])
         )
         self._data['tips_weight'] = (
             self._data[self._treatment_name[0]] +
-            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (
-                1 - self._data[self.propensity_score_column])
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column])
         )
         self._data['cips_weight'] = (
-            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] +
-            (1 - self._data[self._treatment_name[0]])
+            self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] + (1 - self._data[self._treatment_name[0]])
         )
 
         # The Hajek estimator (or the self-normalized estimator)
         self._data['ips_normalized_weight'] = (
             self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] / ipst_sum +
-            (1 - self._data[self._treatment_name[0]]) / (1 -
-                                                         self._data[self.propensity_score_column]) / ipsc_sum
+            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column]) / ipsc_sum
         )
         ipst_for_att_sum = sum(self._data[self._treatment_name[0]])
-        ipsc_for_att_sum = sum((1-self._data[self._treatment_name[0]])/(
-            1 - self._data[self.propensity_score_column])*self._data[self.propensity_score_column])
+        ipsc_for_att_sum = sum((1-self._data[self._treatment_name[0]])/(1 - self._data[self.propensity_score_column])*self._data[self.propensity_score_column])
         self._data['tips_normalized_weight'] = (
             self._data[self._treatment_name[0]] / ipst_for_att_sum +
-            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (
-                1 - self._data[self.propensity_score_column]) / ipsc_for_att_sum
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column]) / ipsc_for_att_sum
         )
-        ipst_for_atc_sum = sum(self._data[self._treatment_name[0]] /
-                               self._data[self.propensity_score_column] * (1-self._data[self.propensity_score_column]))
+        ipst_for_atc_sum = sum(self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] * (1-self._data[self.propensity_score_column]))
         ipsc_for_atc_sum = sum((1 - self._data[self._treatment_name[0]]))
         self._data['cips_normalized_weight'] = (
             self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] / ipst_for_atc_sum +
@@ -130,13 +115,11 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         p_treatment = sum(self._data[self._treatment_name[0]])/num_units
         self._data['ips_stabilized_weight'] = (
             self._data[self._treatment_name[0]] / self._data[self.propensity_score_column] * p_treatment +
-            (1 - self._data[self._treatment_name[0]]) / (1 -
-                                                         self._data[self.propensity_score_column]) * (1 - p_treatment)
+            (1 - self._data[self._treatment_name[0]]) / (1 - self._data[self.propensity_score_column]) * (1 - p_treatment)
         )
         self._data['tips_stabilized_weight'] = (
             self._data[self._treatment_name[0]] * p_treatment +
-            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (
-                1 - self._data[self.propensity_score_column]) * (1 - p_treatment)
+            (1 - self._data[self._treatment_name[0]]) * self._data[self.propensity_score_column] / (1 - self._data[self.propensity_score_column]) * (1 - p_treatment)
         )
         self._data['cips_stabilized_weight'] = (
             self._data[self._treatment_name[0]] * (1 - self._data[self.propensity_score_column]) / self._data[self.propensity_score_column] * p_treatment +
@@ -168,8 +151,7 @@ class PropensityScoreWeightingEstimator(PropensityScoreEstimator):
         sum_dbary_weights = np.sum(
             (1 - self._data[self._treatment_name[0]]) * self._data[weighting_scheme_name])
         # Subtracting the weighted means
-        est = self._data['d_y'].sum() / sum_dy_weights - \
-            self._data['dbar_y'].sum() / sum_dbary_weights
+        est = self._data['d_y'].sum() / sum_dy_weights - self._data['dbar_y'].sum() / sum_dbary_weights
 
         # TODO - how can we add additional information into the returned estimate?
         estimate = CausalEstimate(estimate=est,


### PR DESCRIPTION
1. For propensity-based estimators (i.e. propensity score stratification, matching, inverse propensity weighting), add options to specify either a custom classifier for computing propensity score or an existing column containing pre-computed propensity score.
2. For inverse propensity weighting, added options to specify min_ps_score and max_ps_score.