### PR TITLE
Allow categories to be specified as non-booleans, as long as there are only two

### DIFF
--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -27,7 +27,7 @@ class PropensityScoreEstimator(CausalEstimator):
             error_msg = str(self.__class__) + "cannot handle more than one treatment variable"
             raise Exception(error_msg)
         # Checking if the treatment is binary
-        if not pd.api.types.is_bool_dtype(self._data[self._treatment_name[0]]):
+        if len(self._data[self._treatment_name[0]].unique()) > 2:
             error_msg = "Propensity score methods are applicable only for binary treatments"
             self.logger.error(error_msg)
             raise Exception(error_msg)

--- a/dowhy/causal_estimators/propensity_score_estimator.py
+++ b/dowhy/causal_estimators/propensity_score_estimator.py
@@ -27,7 +27,8 @@ class PropensityScoreEstimator(CausalEstimator):
             error_msg = str(self.__class__) + "cannot handle more than one treatment variable"
             raise Exception(error_msg)
         # Checking if the treatment is binary
-        if len(self._data[self._treatment_name[0]].unique()) > 2:
+        treatment_values = self._data[self._treatment_name[0]].astype(int).unique()
+        if any([v not in [0,1] for v in treatment_values]):
             error_msg = "Propensity score methods are applicable only for binary treatments"
             self.logger.error(error_msg)
             raise Exception(error_msg)


### PR DESCRIPTION
Right now all propensity score methods in dowhy throw an exception if the treatment data type is not boolean. This is far too restrictive, as underlying classifiers work just fine eg with integer 0 and 1 values, and even with floating point 0.0 and 1.0. 

resolves https://github.com/microsoft/dowhy/issues/361