### PR TITLE
method_params["init_params"] for dowhy core estimators

### DIFF
--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -283,6 +283,10 @@ class CausalModel:
                                   treatment_value=treatment_value)
         else:
             if fit_estimator:
+                if method_params is not None and num_components <= 2:
+                    extra_args = method_params.get("init_params", {})
+                else:
+                    extra_args = {}
                 self.causal_estimator = causal_estimator_class(
                     self._data,
                     identified_estimand,
@@ -294,7 +298,8 @@ class CausalModel:
                     confidence_intervals = confidence_intervals,
                     target_units = target_units,
                     effect_modifiers = effect_modifiers,
-                    params=method_params)
+                    params=method_params,
+                    **extra_args)
             else:
                 # Estimator had been computed in a previous call
                 assert self.causal_estimator is not None

--- a/dowhy/causal_model.py
+++ b/dowhy/causal_model.py
@@ -283,7 +283,7 @@ class CausalModel:
                                   treatment_value=treatment_value)
         else:
             if fit_estimator:
-                if method_params is not None and num_components <= 2:
+                if method_params is not None and (num_components <= 2 or estimator_package == 'dowhy'):
                     extra_args = method_params.get("init_params", {})
                 else:
                     extra_args = {}


### PR DESCRIPTION
This allows to use `method_params["init_params"]` with built-in DoWhy estimators, for example propensity_score_weighting_estimator, to supply eg custom propensity models, in a way consistent with how this works for EconML models.

Would resolve https://github.com/microsoft/dowhy/issues/345 and provide another way (consistent with how it's done for EconML estimators) of addressing https://github.com/microsoft/dowhy/issues/303