### PR TITLE
Call EconML estimate and shap_values methods in a way consistent with built-in estimators

### DIFF
--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -155,7 +155,7 @@ class Econml(CausalEstimator):
             expr += " | " + ",".join(self._effect_modifier_names)
         return expr
     
-    def shap_values(self, df: pd.DataFrame, *args, **kwargs) -> "Explanation":
+    def shap_values(self, df: pd.DataFrame, *args, **kwargs):
         return self.estimator.shap_values(
             df[self._effect_modifier_names].values, *args, **kwargs
         )

--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -154,3 +154,18 @@ class Econml(CausalEstimator):
             expr += "+".join(var_list)
             expr += " | " + ",".join(self._effect_modifier_names)
         return expr
+    
+    def shap_values(self, df: pd.DataFrame, *args, **kwargs) -> np.ndarray:
+        return self.estimator.shap_values(
+            df[self._effect_modifier_names].values, *args, **kwargs
+        )
+
+    def effect(self, df: pd.DataFrame, *args, **kwargs) -> np.ndarray:
+        return self.estimator.effect(
+            df[self._effect_modifier_names].values, *args, **kwargs
+        )
+
+    def effect_inference(self, df: pd.DataFrame, *args, **kwargs) -> np.ndarray:
+        return self.estimator.effect_inference(
+            df[self._effect_modifier_names].values, *args, **kwargs
+        )

--- a/dowhy/causal_estimators/econml.py
+++ b/dowhy/causal_estimators/econml.py
@@ -155,7 +155,7 @@ class Econml(CausalEstimator):
             expr += " | " + ",".join(self._effect_modifier_names)
         return expr
     
-    def shap_values(self, df: pd.DataFrame, *args, **kwargs) -> np.ndarray:
+    def shap_values(self, df: pd.DataFrame, *args, **kwargs) -> "Explanation":
         return self.estimator.shap_values(
             df[self._effect_modifier_names].values, *args, **kwargs
         )


### PR DESCRIPTION
Allow to call `effect`, `effect_inference`, and `shap_values` methods of wrapped EconML estimators by just passing in the whole dataframe, like you can with built-in estimators.
Makes it easier to use all estimators in a consistent fashion.

Took me a while to figure out that `_effect_modifier_names` is the only list of column names to use for this that will also work with metalearners, so would like to spare future users that effort